### PR TITLE
가게 Owner 주문 수락 API 구현

### DIFF
--- a/http/order.http
+++ b/http/order.http
@@ -1,0 +1,3 @@
+### 주문 수락
+POST http://localhost:8080/api/owner/orders/11111111-1111-1111-1111-111111111111/accept?memberId=1
+Content-Type: application/json

--- a/src/main/java/com/fourseason/delivery/domain/order/controller/OrderOwnerController.java
+++ b/src/main/java/com/fourseason/delivery/domain/order/controller/OrderOwnerController.java
@@ -1,0 +1,32 @@
+package com.fourseason.delivery.domain.order.controller;
+
+import com.fourseason.delivery.domain.order.service.OrderOwnerService;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/owner/orders")
+public class OrderOwnerController {
+
+  private final OrderOwnerService orderOwnerService;
+
+  /**
+   * 주문 수락 API
+   * role: OWNER
+   */
+  @PostMapping("{orderId}/accept")
+  public ResponseEntity<UUID> acceptOrder(
+      @RequestParam Long memberId, // TODO: @AuthenticationPrincipal 로 변경,
+      @PathVariable UUID orderId
+  ) {
+    orderOwnerService.acceptOrder(memberId, orderId);
+    return ResponseEntity.ok().build();
+  }
+}

--- a/src/main/java/com/fourseason/delivery/domain/order/dto/request/CreateOrderRequestDto.java
+++ b/src/main/java/com/fourseason/delivery/domain/order/dto/request/CreateOrderRequestDto.java
@@ -2,6 +2,7 @@ package com.fourseason.delivery.domain.order.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
 import java.util.List;
 import java.util.UUID;
@@ -9,7 +10,7 @@ import lombok.Builder;
 
 @Builder
 public record CreateOrderRequestDto(
-    @NotBlank(message = "가게 id는 필수 입력 값입니다.")
+    @NotNull(message = "가게 id는 필수 입력 값입니다.")
     UUID shopId,
 
     @NotBlank(message = "주소는 필수 입력 값입니다.")
@@ -24,7 +25,7 @@ public record CreateOrderRequestDto(
 
   @Builder
   public record MenuDto(
-      @NotBlank
+      @NotNull
       UUID menuId,
 
       @Positive

--- a/src/main/java/com/fourseason/delivery/domain/order/entity/Order.java
+++ b/src/main/java/com/fourseason/delivery/domain/order/entity/Order.java
@@ -1,13 +1,23 @@
 package com.fourseason.delivery.domain.order.entity;
 
-import static jakarta.persistence.CascadeType.*;
-import static jakarta.persistence.FetchType.*;
+import static com.fourseason.delivery.domain.order.exception.OrderErrorCode.NOT_SHOP_OWNER;
+import static jakarta.persistence.CascadeType.PERSIST;
+import static jakarta.persistence.FetchType.LAZY;
 
 import com.fourseason.delivery.domain.member.entity.Member;
 import com.fourseason.delivery.domain.order.dto.request.CreateOrderRequestDto;
 import com.fourseason.delivery.domain.shop.entity.Shop;
 import com.fourseason.delivery.global.entity.BaseTimeEntity;
-import jakarta.persistence.*;
+import com.fourseason.delivery.global.exception.CustomException;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
 import java.util.List;
 import java.util.UUID;
 import lombok.AccessLevel;
@@ -25,59 +35,69 @@ import org.hibernate.annotations.UuidGenerator;
 @AllArgsConstructor
 public class Order extends BaseTimeEntity {
 
-    @Id
-    @UuidGenerator
-    private UUID id;
+  @Id
+  @UuidGenerator
+  private UUID id;
 
-    @ManyToOne
-    @JoinColumn(name = "shop_id")
-    private Shop shop;
+  @ManyToOne
+  @JoinColumn(name = "shop_id")
+  private Shop shop;
 
-    @ManyToOne
-    @JoinColumn(name = "member_id")
-    private Member member;
+  @ManyToOne
+  @JoinColumn(name = "member_id")
+  private Member member;
 
-    @OneToMany(fetch = LAZY, cascade = PERSIST)
-    private List<OrderMenu> orderMenuList;
+  @OneToMany(fetch = LAZY, cascade = PERSIST)
+  private List<OrderMenu> orderMenuList;
 
-    @Enumerated(EnumType.STRING)
-    @Column(nullable = false)
-    private OrderStatus orderStatus;
+  @Enumerated(EnumType.STRING)
+  @Column(nullable = false)
+  private OrderStatus orderStatus;
 
-    @Column(nullable = false)
-    private String address;
+  @Column(nullable = false)
+  private String address;
 
-    private String instruction;
+  private String instruction;
 
-    @Column(nullable = false)
-    private int totalPrice;
+  @Column(nullable = false)
+  private int totalPrice;
 
-    @Builder
-    private Order(Shop shop, Member member, List<OrderMenu> orderMenuList,
-        OrderStatus orderStatus, String address, String instruction, int totalPrice) {
-        this.shop = shop;
-        this.member = member;
-        this.orderMenuList = orderMenuList;
-        this.orderStatus = orderStatus;
-        this.address = address;
-        this.instruction = instruction;
-        this.totalPrice = totalPrice;
+  @Builder
+  private Order(Shop shop, Member member, List<OrderMenu> orderMenuList,
+      OrderStatus orderStatus, String address, String instruction, int totalPrice) {
+    this.shop = shop;
+    this.member = member;
+    this.orderMenuList = orderMenuList;
+    this.orderStatus = orderStatus;
+    this.address = address;
+    this.instruction = instruction;
+    this.totalPrice = totalPrice;
+  }
+
+  public static Order addOf(
+      CreateOrderRequestDto dto,
+      Shop shop,
+      Member member,
+      List<OrderMenu> orderMenuList,
+      int totalPrice) {
+    return Order.builder()
+        .shop(shop)
+        .member(member)
+        .orderStatus(OrderStatus.PENDING)
+        .address(dto.address())
+        .instruction(dto.instruction())
+        .totalPrice(totalPrice)
+        .orderMenuList(orderMenuList)
+        .build();
+  }
+
+  public void updateStatus(OrderStatus orderStatus) {
+    this.orderStatus = orderStatus;
+  }
+
+  public void validateShopOwner(Long ownerId) {
+    if (!this.getShop().getMember().getId().equals(ownerId)) {
+      throw new CustomException(NOT_SHOP_OWNER);
     }
-
-    public static Order addOf(
-        CreateOrderRequestDto dto,
-        Shop shop,
-        Member member,
-        List<OrderMenu> orderMenuList,
-        int totalPrice) {
-        return Order.builder()
-            .shop(shop)
-            .member(member)
-            .orderStatus(OrderStatus.PENDING)
-            .address(dto.address())
-            .instruction(dto.instruction())
-            .totalPrice(totalPrice)
-            .orderMenuList(orderMenuList)
-            .build();
-    }
+  }
 }

--- a/src/main/java/com/fourseason/delivery/domain/order/exception/OrderErrorCode.java
+++ b/src/main/java/com/fourseason/delivery/domain/order/exception/OrderErrorCode.java
@@ -8,8 +8,9 @@ import org.springframework.http.HttpStatus;
 public enum OrderErrorCode implements ErrorCode {
 
   ORDER_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 주문을 찾을 수 없습니다."),
+  NOT_SHOP_OWNER(HttpStatus.BAD_REQUEST, "가게 주인이 아닙니다."),
 
-  // TODO: 각 도메인 ErrorCode 로 옮기기
+  // TODO: 각 도메인 ErrorCode 로 옮기기,
   MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 회원을 찾을 수 없습니다."),
   MENU_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 메뉴를 찾을 수 없습니다."),
   ;

--- a/src/main/java/com/fourseason/delivery/domain/order/service/OrderOwnerService.java
+++ b/src/main/java/com/fourseason/delivery/domain/order/service/OrderOwnerService.java
@@ -1,0 +1,30 @@
+package com.fourseason.delivery.domain.order.service;
+
+import static com.fourseason.delivery.domain.order.entity.OrderStatus.ACCEPTED;
+import static com.fourseason.delivery.domain.order.exception.OrderErrorCode.ORDER_NOT_FOUND;
+
+import com.fourseason.delivery.domain.order.entity.Order;
+import com.fourseason.delivery.domain.order.repository.OrderRepository;
+import com.fourseason.delivery.global.exception.CustomException;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class OrderOwnerService {
+
+  private final OrderRepository orderRepository;
+
+  @Transactional
+  public void acceptOrder(Long ownerId, UUID orderId) {
+
+    Order order = orderRepository.findById(orderId).
+        orElseThrow(() -> new CustomException(ORDER_NOT_FOUND));
+
+    order.validateShopOwner(ownerId);
+
+    order.updateStatus(ACCEPTED);
+  }
+}

--- a/src/test/java/com/fourseason/delivery/domain/order/service/OrderOwnerServiceTest.java
+++ b/src/test/java/com/fourseason/delivery/domain/order/service/OrderOwnerServiceTest.java
@@ -1,0 +1,106 @@
+package com.fourseason.delivery.domain.order.service;
+
+import static com.fourseason.delivery.domain.order.entity.OrderStatus.ACCEPTED;
+import static com.fourseason.delivery.domain.order.exception.OrderErrorCode.ORDER_NOT_FOUND;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+
+import com.fourseason.delivery.domain.member.entity.Member;
+import com.fourseason.delivery.domain.order.entity.Order;
+import com.fourseason.delivery.domain.order.repository.OrderRepository;
+import com.fourseason.delivery.domain.shop.entity.Shop;
+import com.fourseason.delivery.global.exception.CustomException;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class OrderOwnerServiceTest {
+
+  @Mock
+  OrderRepository orderRepository;
+
+  @InjectMocks
+  OrderOwnerService orderOwnerService;
+
+  @Nested
+  class acceptOrder {
+
+    Long ownerId = 1L;
+
+    UUID orderId = UUID.randomUUID();
+
+    @Test
+    @DisplayName("주문 수락 시 존재하지 않은 주문이면 예외가 발생한다.")
+    void order_not_found() {
+      // given
+      when(orderRepository.findById(orderId)).thenThrow(new CustomException(ORDER_NOT_FOUND));
+
+      // when  
+      // then      
+      assertThatThrownBy(() -> orderOwnerService.acceptOrder(ownerId, orderId))
+          .isInstanceOf(CustomException.class)
+          .hasMessage("해당 주문을 찾을 수 없습니다.");
+    }
+
+    @Test
+    @DisplayName("주문 수락 시 해당 가게의 주문이 아니면 예외가 발생한다.")
+    void not_shop_order() {
+      // given
+      Member owner = Member.builder().build();
+      ReflectionTestUtils.setField(owner, "id", ownerId);
+
+      Long anotherId = 2L;
+      Member another = Member.builder().build();
+      ReflectionTestUtils.setField(another, "id", anotherId);
+
+      Shop anotherShop = Shop.builder()
+          .member(another)
+          .build();
+
+      Order anotherOrder = Order.builder()
+          .shop(anotherShop)
+          .build();
+
+      when(orderRepository.findById(orderId)).thenReturn(Optional.of(anotherOrder));
+
+      // when
+      // then
+      assertThatThrownBy(() -> orderOwnerService.acceptOrder(ownerId, orderId))
+          .isInstanceOf(CustomException.class)
+          .hasMessage("가게 주인이 아닙니다.");
+    }
+
+    @Test
+    @DisplayName("주문 수락 성공")
+    void success() {
+      // given
+      Member owner = Member.builder().build();
+      ReflectionTestUtils.setField(owner, "id", ownerId);
+
+      Shop shop = Shop.builder()
+          .member(owner)
+          .build();
+
+      Order order = Order.builder()
+          .shop(shop)
+          .build();
+
+      when(orderRepository.findById(orderId)).thenReturn(Optional.of(order));
+
+      // when
+      orderOwnerService.acceptOrder(ownerId, orderId);
+
+      // then
+      assertThat(order.getOrderStatus()).isEqualTo(ACCEPTED);
+    }
+  }
+}


### PR DESCRIPTION
## 요약

가게 Owner 주문 수락 API 구현

## 작업 내용

- 가게 Owner 주문 수락 API 구현
- 테스트 코드 작성

## 참고 사항

- RequestDto에서 UUID 타입은 `@NotNull`로 validation 될 수 있도록 변경하였습니다.

## 관련 이슈
#10 