### PR TITLE
고객 주문 조회 API

### DIFF
--- a/http/order.http
+++ b/http/order.http
@@ -1,3 +1,27 @@
-### 주문 수락
-POST http://localhost:8080/api/owner/orders/11111111-1111-1111-1111-111111111111/accept?memberId=1
+### 고객 주문 요청
+POST http://localhost:8080/api/customer/orders?memberId=5
 Content-Type: application/json
+
+{
+  "shopId": "00000000-0000-0000-0000-000000000010",
+  "address": "주소",
+  "menuList": [
+    {
+      "menuId": "00000000-0000-0000-0000-000000000101",
+      "quantity": 1
+    },
+    {
+      "menuId": "00000000-0000-0000-0000-000000000102",
+      "quantity": 2
+    }
+  ]
+}
+
+### 고객 주문 리스트 조회
+GET http://localhost:8080/api/customer/orders?memberId=5&page=1&size=20&orderBy=latest
+Content-Type: application/json
+
+### 주문 수락
+POST http://localhost:8080/api/owner/orders/adb6b9a4-77e5-4e77-a22f-61cd0f7a7f39/accept?memberId=3
+Content-Type: application/json
+

--- a/http/order.http
+++ b/http/order.http
@@ -17,6 +17,9 @@ Content-Type: application/json
   ]
 }
 
+### 고객 주문 상세 조회
+GET http://localhost:8080/api/customer/orders/adb6b9a4-77e5-4e77-a22f-61cd0f7a7f39?memberId=5
+
 ### 고객 주문 리스트 조회
 GET http://localhost:8080/api/customer/orders?memberId=5&page=1&size=20&orderBy=latest
 Content-Type: application/json

--- a/src/main/java/com/fourseason/delivery/domain/menu/repository/MenuRepository.java
+++ b/src/main/java/com/fourseason/delivery/domain/menu/repository/MenuRepository.java
@@ -10,5 +10,5 @@ import java.util.Optional;
 
 public interface MenuRepository extends JpaRepository<Menu, UUID> {
     Optional<Menu> findByIdAndDeletedAtIsNull(UUID id);
-    List<Menu> findByIdIn(List<UUID> menuIds);
+    List<Menu> findByIdInAndDeletedAtIsNull(List<UUID> menuIds);
 }

--- a/src/main/java/com/fourseason/delivery/domain/order/controller/OrderCustomerController.java
+++ b/src/main/java/com/fourseason/delivery/domain/order/controller/OrderCustomerController.java
@@ -1,7 +1,8 @@
 package com.fourseason.delivery.domain.order.controller;
 
 import com.fourseason.delivery.domain.order.dto.request.CreateOrderRequestDto;
-import com.fourseason.delivery.domain.order.dto.response.OrderResponseDto;
+import com.fourseason.delivery.domain.order.dto.response.OrderDetailResponseDto;
+import com.fourseason.delivery.domain.order.dto.response.OrderSummaryResponseDto;
 import com.fourseason.delivery.domain.order.service.OrderCustomerService;
 import com.fourseason.delivery.global.dto.PageRequestDto;
 import com.fourseason.delivery.global.dto.PageResponseDto;
@@ -44,7 +45,7 @@ public class OrderCustomerController {
    * 고객의 주문 상세 조회 API role: CUSTOMER
    */
   @GetMapping("/{orderId}")
-  public ResponseEntity<OrderResponseDto> getOrder(
+  public ResponseEntity<OrderDetailResponseDto> getOrder(
       @PathVariable UUID orderId,
       @RequestParam Long memberId
   ) {
@@ -55,7 +56,7 @@ public class OrderCustomerController {
    * 고객 주문 목록 조회 API role: CUSTOMER
    */
   @GetMapping
-  public ResponseEntity<PageResponseDto<OrderResponseDto>> getOrderList(
+  public ResponseEntity<PageResponseDto<OrderSummaryResponseDto>> getOrderList(
       @RequestParam Long memberId,
       @RequestParam(defaultValue = "1") int page,
       @RequestParam(defaultValue = "10") int size,

--- a/src/main/java/com/fourseason/delivery/domain/order/controller/OrderCustomerController.java
+++ b/src/main/java/com/fourseason/delivery/domain/order/controller/OrderCustomerController.java
@@ -1,16 +1,22 @@
 package com.fourseason.delivery.domain.order.controller;
 
 import com.fourseason.delivery.domain.order.dto.request.CreateOrderRequestDto;
+import com.fourseason.delivery.domain.order.dto.response.OrderResponseDto;
 import com.fourseason.delivery.domain.order.service.OrderCustomerService;
+import com.fourseason.delivery.global.dto.PageRequestDto;
+import com.fourseason.delivery.global.dto.PageResponseDto;
 import jakarta.validation.Valid;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.util.UriComponentsBuilder;
 
 @RestController
 @RequiredArgsConstructor
@@ -20,14 +26,38 @@ public class OrderCustomerController {
   private final OrderCustomerService orderCustomerService;
 
   /**
-   * 주문 요청 API
-   * role: CUSTOMER
+   * 고객 주문 요청 API role: CUSTOMER
    */
   @PostMapping
   public ResponseEntity<UUID> createOrder(
       @RequestBody @Valid CreateOrderRequestDto request,
       @RequestParam Long memberId // TODO: @AuthenticationPrincipal 로 변경
   ) {
-    return ResponseEntity.ok(orderCustomerService.createOrder(request, memberId));
+    UUID orderId = orderCustomerService.createOrder(request, memberId);
+    return ResponseEntity.created(
+        UriComponentsBuilder.fromUriString("/api/customer/orders/{orderId}")
+            .buildAndExpand(orderId)
+            .toUri()).build();
+  }
+
+  /**
+   * 고객의 주문 상세 조회 API role: CUSTOMER
+   */
+  @GetMapping("/{orderId}")
+  public ResponseEntity<OrderResponseDto> getOrder(@PathVariable UUID orderId) {
+    return ResponseEntity.ok(orderCustomerService.getOrder(orderId));
+  }
+
+  /**
+   * 고객 주문 목록 조회 API role: CUSTOMER
+   */
+  @GetMapping
+  public ResponseEntity<PageResponseDto<OrderResponseDto>> getOrderList(
+      @RequestParam Long memberId,
+      @RequestParam(defaultValue = "1") int page,
+      @RequestParam(defaultValue = "10") int size,
+      @RequestParam(defaultValue = "latest") String orderBy) {
+    PageRequestDto pageRequestDto = PageRequestDto.of(page - 1, size, orderBy);
+    return ResponseEntity.ok(orderCustomerService.getOrderList(memberId, pageRequestDto));
   }
 }

--- a/src/main/java/com/fourseason/delivery/domain/order/controller/OrderCustomerController.java
+++ b/src/main/java/com/fourseason/delivery/domain/order/controller/OrderCustomerController.java
@@ -44,8 +44,11 @@ public class OrderCustomerController {
    * 고객의 주문 상세 조회 API role: CUSTOMER
    */
   @GetMapping("/{orderId}")
-  public ResponseEntity<OrderResponseDto> getOrder(@PathVariable UUID orderId) {
-    return ResponseEntity.ok(orderCustomerService.getOrder(orderId));
+  public ResponseEntity<OrderResponseDto> getOrder(
+      @PathVariable UUID orderId,
+      @RequestParam Long memberId
+  ) {
+    return ResponseEntity.ok(orderCustomerService.getOrder(orderId, memberId));
   }
 
   /**

--- a/src/main/java/com/fourseason/delivery/domain/order/dto/response/OrderDetailResponseDto.java
+++ b/src/main/java/com/fourseason/delivery/domain/order/dto/response/OrderDetailResponseDto.java
@@ -6,12 +6,11 @@ import com.fourseason.delivery.domain.order.entity.Order;
 import com.fourseason.delivery.domain.order.entity.OrderMenu;
 import com.fourseason.delivery.domain.order.entity.OrderStatus;
 import com.fourseason.delivery.domain.order.entity.OrderType;
-import com.querydsl.core.annotations.QueryProjection;
 import java.time.LocalDateTime;
 import java.util.List;
 import lombok.Builder;
 
-public record OrderResponseDto(
+public record OrderDetailResponseDto(
     String shopName,
     String address,
     String instruction,
@@ -24,8 +23,7 @@ public record OrderResponseDto(
     String updatedBy
 ) {
 
-  @QueryProjection
-  public OrderResponseDto(Order order) {
+  public OrderDetailResponseDto(Order order) {
     this(order.getShop().getName(),
         order.getAddress(),
         order.getInstruction(),
@@ -39,8 +37,8 @@ public record OrderResponseDto(
     );
   }
 
-  public static OrderResponseDto of(Order order) {
-    return new OrderResponseDto(
+  public static OrderDetailResponseDto of(Order order) {
+    return new OrderDetailResponseDto(
         order.getShop().getName(),
         order.getAddress(),
         order.getInstruction(),

--- a/src/main/java/com/fourseason/delivery/domain/order/dto/response/OrderResponseDto.java
+++ b/src/main/java/com/fourseason/delivery/domain/order/dto/response/OrderResponseDto.java
@@ -1,0 +1,52 @@
+package com.fourseason.delivery.domain.order.dto.response;
+
+import static java.util.stream.Collectors.toList;
+
+import com.fourseason.delivery.domain.order.entity.Order;
+import com.fourseason.delivery.domain.order.entity.OrderMenu;
+import com.fourseason.delivery.domain.order.entity.OrderStatus;
+import com.fourseason.delivery.domain.order.entity.OrderType;
+import java.util.List;
+import lombok.Builder;
+
+@Builder
+public record OrderResponseDto(
+    String shopName,
+    String address,
+    String instruction,
+    int totalPrice,
+    OrderStatus status,
+    OrderType type,
+    List<MenuDto> menuList
+) {
+
+  public static OrderResponseDto of(Order order) {
+    return OrderResponseDto.builder()
+        .shopName(order.getShop().getName())
+        .address(order.getAddress())
+        .instruction(order.getInstruction())
+        .totalPrice(order.getTotalPrice())
+        .status(order.getOrderStatus())
+        .type(order.getOrderType())
+        .menuList(order.getOrderMenuList().stream().map(MenuDto::of).collect(toList()))
+        .build();
+  }
+
+  @Builder
+  public record MenuDto(
+      String name,
+      int price,
+      int quantity,
+      int totalPrice
+  ) {
+
+    public static MenuDto of(OrderMenu orderMenu) {
+      return MenuDto.builder()
+          .name(orderMenu.getName())
+          .price(orderMenu.getPrice())
+          .quantity(orderMenu.getQuantity())
+          .totalPrice(orderMenu.getPrice() * orderMenu.getQuantity())
+          .build();
+    }
+  }
+}

--- a/src/main/java/com/fourseason/delivery/domain/order/dto/response/OrderResponseDto.java
+++ b/src/main/java/com/fourseason/delivery/domain/order/dto/response/OrderResponseDto.java
@@ -6,38 +6,60 @@ import com.fourseason.delivery.domain.order.entity.Order;
 import com.fourseason.delivery.domain.order.entity.OrderMenu;
 import com.fourseason.delivery.domain.order.entity.OrderStatus;
 import com.fourseason.delivery.domain.order.entity.OrderType;
+import com.querydsl.core.annotations.QueryProjection;
+import java.time.LocalDateTime;
 import java.util.List;
 import lombok.Builder;
 
-@Builder
 public record OrderResponseDto(
     String shopName,
     String address,
     String instruction,
-    int totalPrice,
+    Integer totalPrice,
     OrderStatus status,
     OrderType type,
-    List<MenuDto> menuList
+    List<MenuDto> menuList,
+    LocalDateTime createdAt,
+    LocalDateTime updatedAt,
+    String updatedBy
 ) {
 
+  @QueryProjection
+  public OrderResponseDto(Order order) {
+    this(order.getShop().getName(),
+        order.getAddress(),
+        order.getInstruction(),
+        order.getTotalPrice(),
+        order.getOrderStatus(),
+        order.getOrderType(),
+        order.getOrderMenuList().stream().map(MenuDto::of).collect(toList()),
+        order.getCreatedAt(),
+        order.getUpdatedAt(),
+        order.getUpdatedBy()
+    );
+  }
+
   public static OrderResponseDto of(Order order) {
-    return OrderResponseDto.builder()
-        .shopName(order.getShop().getName())
-        .address(order.getAddress())
-        .instruction(order.getInstruction())
-        .totalPrice(order.getTotalPrice())
-        .status(order.getOrderStatus())
-        .type(order.getOrderType())
-        .menuList(order.getOrderMenuList().stream().map(MenuDto::of).collect(toList()))
-        .build();
+    return new OrderResponseDto(
+        order.getShop().getName(),
+        order.getAddress(),
+        order.getInstruction(),
+        order.getTotalPrice(),
+        order.getOrderStatus(),
+        order.getOrderType(),
+        order.getOrderMenuList().stream().map(MenuDto::of).collect(toList()),
+        order.getCreatedAt(),
+        order.getUpdatedAt(),
+        order.getUpdatedBy()
+    );
   }
 
   @Builder
   public record MenuDto(
       String name,
-      int price,
-      int quantity,
-      int totalPrice
+      Integer price,
+      Integer quantity,
+      Integer totalPrice
   ) {
 
     public static MenuDto of(OrderMenu orderMenu) {

--- a/src/main/java/com/fourseason/delivery/domain/order/dto/response/OrderSummaryResponseDto.java
+++ b/src/main/java/com/fourseason/delivery/domain/order/dto/response/OrderSummaryResponseDto.java
@@ -1,0 +1,63 @@
+package com.fourseason.delivery.domain.order.dto.response;
+
+import static java.util.stream.Collectors.toList;
+
+import com.fourseason.delivery.domain.order.entity.Order;
+import com.fourseason.delivery.domain.order.entity.OrderMenu;
+import com.fourseason.delivery.domain.order.entity.OrderStatus;
+import com.querydsl.core.annotations.QueryProjection;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.Builder;
+
+public record OrderSummaryResponseDto(
+    String shopName,
+    String address,
+    Integer totalPrice,
+    OrderStatus status,
+    List<MenuDto> menuList,
+    LocalDateTime createdAt,
+    LocalDateTime updatedAt,
+    String updatedBy
+) {
+
+  @QueryProjection
+  public OrderSummaryResponseDto(Order order) {
+    this(order.getShop().getName(),
+        order.getAddress(),
+        order.getTotalPrice(),
+        order.getOrderStatus(),
+        order.getOrderMenuList().stream().map(MenuDto::of).collect(toList()),
+        order.getCreatedAt(),
+        order.getUpdatedAt(),
+        order.getUpdatedBy()
+    );
+  }
+
+  public static OrderSummaryResponseDto of(Order order) {
+    return new OrderSummaryResponseDto(
+        order.getShop().getName(),
+        order.getAddress(),
+        order.getTotalPrice(),
+        order.getOrderStatus(),
+        order.getOrderMenuList().stream().map(MenuDto::of).collect(toList()),
+        order.getCreatedAt(),
+        order.getUpdatedAt(),
+        order.getUpdatedBy()
+    );
+  }
+
+  @Builder
+  public record MenuDto(
+      String name,
+      Integer quantity
+  ) {
+
+    public static MenuDto of(OrderMenu orderMenu) {
+      return MenuDto.builder()
+          .name(orderMenu.getName())
+          .quantity(orderMenu.getQuantity())
+          .build();
+    }
+  }
+}

--- a/src/main/java/com/fourseason/delivery/domain/order/entity/Order.java
+++ b/src/main/java/com/fourseason/delivery/domain/order/entity/Order.java
@@ -1,5 +1,8 @@
 package com.fourseason.delivery.domain.order.entity;
 
+import static com.fourseason.delivery.domain.order.entity.OrderStatus.*;
+import static com.fourseason.delivery.domain.order.entity.OrderType.*;
+import static com.fourseason.delivery.domain.order.exception.OrderErrorCode.NOT_PENDING_ORDER;
 import static com.fourseason.delivery.domain.order.exception.OrderErrorCode.NOT_SHOP_OWNER;
 import static jakarta.persistence.CascadeType.PERSIST;
 import static jakarta.persistence.FetchType.LAZY;
@@ -54,6 +57,10 @@ public class Order extends BaseTimeEntity {
   @Column(nullable = false)
   private OrderStatus orderStatus;
 
+  @Enumerated(EnumType.STRING)
+  @Column(nullable = false)
+  private OrderType orderType;
+
   @Column(nullable = false)
   private String address;
 
@@ -64,26 +71,29 @@ public class Order extends BaseTimeEntity {
 
   @Builder
   private Order(Shop shop, Member member, List<OrderMenu> orderMenuList,
-      OrderStatus orderStatus, String address, String instruction, int totalPrice) {
+      OrderStatus orderStatus, OrderType orderType, String address, String instruction, int totalPrice) {
     this.shop = shop;
     this.member = member;
     this.orderMenuList = orderMenuList;
+    this.orderType = orderType;
     this.orderStatus = orderStatus;
     this.address = address;
     this.instruction = instruction;
     this.totalPrice = totalPrice;
   }
 
-  public static Order addOf(
+  public static Order addByOnlineOrder(
       CreateOrderRequestDto dto,
       Shop shop,
       Member member,
       List<OrderMenu> orderMenuList,
-      int totalPrice) {
+      int totalPrice
+  ) {
     return Order.builder()
         .shop(shop)
         .member(member)
-        .orderStatus(OrderStatus.PENDING)
+        .orderStatus(PENDING)
+        .orderType(ONLINE)
         .address(dto.address())
         .instruction(dto.instruction())
         .totalPrice(totalPrice)
@@ -95,9 +105,15 @@ public class Order extends BaseTimeEntity {
     this.orderStatus = orderStatus;
   }
 
-  public void validateShopOwner(Long ownerId) {
+  public void assertShopOwner(Long ownerId) {
     if (!this.getShop().getMember().getId().equals(ownerId)) {
       throw new CustomException(NOT_SHOP_OWNER);
+    }
+  }
+
+  public void assertOrderIsPending() {
+    if (this.orderStatus != OrderStatus.PENDING) {
+      throw new CustomException(NOT_PENDING_ORDER);
     }
   }
 }

--- a/src/main/java/com/fourseason/delivery/domain/order/entity/Order.java
+++ b/src/main/java/com/fourseason/delivery/domain/order/entity/Order.java
@@ -2,6 +2,7 @@ package com.fourseason.delivery.domain.order.entity;
 
 import static com.fourseason.delivery.domain.order.entity.OrderStatus.*;
 import static com.fourseason.delivery.domain.order.entity.OrderType.*;
+import static com.fourseason.delivery.domain.order.exception.OrderErrorCode.*;
 import static com.fourseason.delivery.domain.order.exception.OrderErrorCode.NOT_PENDING_ORDER;
 import static com.fourseason.delivery.domain.order.exception.OrderErrorCode.NOT_SHOP_OWNER;
 import static jakarta.persistence.CascadeType.PERSIST;
@@ -9,6 +10,7 @@ import static jakarta.persistence.FetchType.LAZY;
 
 import com.fourseason.delivery.domain.member.entity.Member;
 import com.fourseason.delivery.domain.order.dto.request.CreateOrderRequestDto;
+import com.fourseason.delivery.domain.order.exception.OrderErrorCode;
 import com.fourseason.delivery.domain.shop.entity.Shop;
 import com.fourseason.delivery.global.entity.BaseTimeEntity;
 import com.fourseason.delivery.global.exception.CustomException;
@@ -114,6 +116,12 @@ public class Order extends BaseTimeEntity {
   public void assertOrderIsPending() {
     if (this.orderStatus != OrderStatus.PENDING) {
       throw new CustomException(NOT_PENDING_ORDER);
+    }
+  }
+
+  public void assertOrderedBy(Long customerId) {
+    if (!this.getMember().getId().equals(customerId)) {
+      throw new CustomException(NOT_ORDERED_BY_CUSTOMER);
     }
   }
 }

--- a/src/main/java/com/fourseason/delivery/domain/order/entity/OrderMenu.java
+++ b/src/main/java/com/fourseason/delivery/domain/order/entity/OrderMenu.java
@@ -34,25 +34,28 @@ public class OrderMenu extends BaseTimeEntity {
   private Menu menu;
 
   @Column(nullable = false)
-  private int menuPrice;
+  private String name;
+
+  @Column(nullable = false)
+  private int price;
 
   @Column(nullable = false)
   private int quantity;
 
-  public static OrderMenu addOf(Menu menu, int menuPrice, int quantity) {
+  public static OrderMenu addOf(Menu menu, int quantity) {
     return OrderMenu.builder()
         .menu(menu)
-        .menuPrice(menuPrice)
+        .name(menu.getName())
+        .price(menu.getPrice())
         .quantity(quantity)
         .build();
   }
 
   @Builder
-  private OrderMenu(UUID id, int quantity, int menuPrice, Menu menu, Order order) {
-    this.id = id;
-    this.quantity = quantity;
-    this.menuPrice = menuPrice;
+  private OrderMenu(Menu menu, String name, int quantity, int price) {
     this.menu = menu;
-    this.order = order;
+    this.name = name;
+    this.price = price;
+    this.quantity = quantity;
   }
 }

--- a/src/main/java/com/fourseason/delivery/domain/order/entity/OrderType.java
+++ b/src/main/java/com/fourseason/delivery/domain/order/entity/OrderType.java
@@ -1,0 +1,10 @@
+package com.fourseason.delivery.domain.order.entity;
+
+public enum OrderType {
+    ONLINE,
+    OFFLINE;
+
+    public static OrderType of(String status) {
+        return valueOf(status);
+    }
+}

--- a/src/main/java/com/fourseason/delivery/domain/order/exception/OrderErrorCode.java
+++ b/src/main/java/com/fourseason/delivery/domain/order/exception/OrderErrorCode.java
@@ -9,10 +9,12 @@ public enum OrderErrorCode implements ErrorCode {
 
   ORDER_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 주문을 찾을 수 없습니다."),
   NOT_SHOP_OWNER(HttpStatus.BAD_REQUEST, "가게 주인이 아닙니다."),
+  NOT_PENDING_ORDER(HttpStatus.BAD_REQUEST, "보류 중인 주문이 아닙니다."),
 
   // TODO: 각 도메인 ErrorCode 로 옮기기,
   MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 회원을 찾을 수 없습니다."),
   MENU_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 메뉴를 찾을 수 없습니다."),
+
   ;
 
   private final HttpStatus httpStatus;

--- a/src/main/java/com/fourseason/delivery/domain/order/exception/OrderErrorCode.java
+++ b/src/main/java/com/fourseason/delivery/domain/order/exception/OrderErrorCode.java
@@ -10,12 +10,12 @@ public enum OrderErrorCode implements ErrorCode {
   ORDER_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 주문을 찾을 수 없습니다."),
   NOT_SHOP_OWNER(HttpStatus.BAD_REQUEST, "가게 주인이 아닙니다."),
   NOT_PENDING_ORDER(HttpStatus.BAD_REQUEST, "보류 중인 주문이 아닙니다."),
+  NOT_ORDERED_BY_CUSTOMER(HttpStatus.BAD_REQUEST, "해당 주문을 요청한 고객이 아닙니다."),
 
   // TODO: 각 도메인 ErrorCode 로 옮기기,
   MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 회원을 찾을 수 없습니다."),
-  MENU_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 메뉴를 찾을 수 없습니다."),
+  MENU_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 메뉴를 찾을 수 없습니다.");
 
-  ;
 
   private final HttpStatus httpStatus;
   private final String message;

--- a/src/main/java/com/fourseason/delivery/domain/order/repository/OrderRepositoryCustom.java
+++ b/src/main/java/com/fourseason/delivery/domain/order/repository/OrderRepositoryCustom.java
@@ -3,8 +3,8 @@ package com.fourseason.delivery.domain.order.repository;
 import static com.fourseason.delivery.domain.order.entity.QOrder.order;
 
 import com.fourseason.delivery.domain.menu.exception.MenuErrorCode;
-import com.fourseason.delivery.domain.order.dto.response.OrderResponseDto;
-import com.fourseason.delivery.domain.order.dto.response.QOrderResponseDto;
+import com.fourseason.delivery.domain.order.dto.response.OrderSummaryResponseDto;
+import com.fourseason.delivery.domain.order.dto.response.QOrderSummaryResponseDto;
 import com.fourseason.delivery.domain.order.entity.QOrder;
 import com.fourseason.delivery.global.dto.PageRequestDto;
 import com.fourseason.delivery.global.dto.PageResponseDto;
@@ -27,9 +27,9 @@ public class OrderRepositoryCustom {
   /**
    * 주문 목록 조회
    */
-  public PageResponseDto<OrderResponseDto> findOrderListWithPage(Long memberId,
+  public PageResponseDto<OrderSummaryResponseDto> findOrderListWithPage(Long memberId,
       PageRequestDto pageRequestDto) {
-    List<OrderResponseDto> content = getOrderList(memberId, pageRequestDto);
+    List<OrderSummaryResponseDto> content = getOrderList(memberId, pageRequestDto);
     long total = getTotalDataCount(memberId);
 
     return new PageResponseDto<>(content, total);
@@ -38,9 +38,9 @@ public class OrderRepositoryCustom {
   /**
    * 페이징 결과 조회 메서드
    */
-  private List<OrderResponseDto> getOrderList(Long memberId, PageRequestDto pageRequestDto) {
-    JPAQuery<OrderResponseDto> query = jpaQueryFactory
-        .select(new QOrderResponseDto(order))
+  private List<OrderSummaryResponseDto> getOrderList(Long memberId, PageRequestDto pageRequestDto) {
+    JPAQuery<OrderSummaryResponseDto> query = jpaQueryFactory
+        .select(new QOrderSummaryResponseDto(order))
         .from(order)
         .where(getWhereConditions(memberId))
         .offset(pageRequestDto.getFirstIndex())

--- a/src/main/java/com/fourseason/delivery/domain/order/repository/OrderRepositoryCustom.java
+++ b/src/main/java/com/fourseason/delivery/domain/order/repository/OrderRepositoryCustom.java
@@ -1,0 +1,105 @@
+package com.fourseason.delivery.domain.order.repository;
+
+import static com.fourseason.delivery.domain.order.entity.QOrder.order;
+import static com.fourseason.delivery.domain.order.entity.QOrderMenu.orderMenu;
+
+import com.fourseason.delivery.domain.menu.exception.MenuErrorCode;
+import com.fourseason.delivery.domain.order.dto.response.OrderResponseDto;
+import com.fourseason.delivery.domain.order.entity.QOrder;
+import com.fourseason.delivery.global.dto.PageRequestDto;
+import com.fourseason.delivery.global.dto.PageResponseDto;
+import com.fourseason.delivery.global.exception.CustomException;
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.group.GroupBy;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class OrderRepositoryCustom {
+
+  private final JPAQueryFactory jpaQueryFactory;
+
+  /**
+   * 주문 목록 조회
+   */
+  public PageResponseDto<OrderResponseDto> findOrderListWithPage(Long memberId,
+      PageRequestDto pageRequestDto) {
+    List<OrderResponseDto> content = getOrderList(memberId, pageRequestDto);
+    long total = getTotalDataCount(memberId);
+
+    return new PageResponseDto<>(content, total);
+  }
+
+  /**
+   * 페이징 결과 조회 메서드
+   */
+  private List<OrderResponseDto> getOrderList(Long memberId, PageRequestDto pageRequestDto) {
+    return jpaQueryFactory
+        .select(
+            Projections.constructor(OrderResponseDto.class,
+                order.shop.name,
+                order.address,
+                order.instruction,
+                order.totalPrice,
+                order.orderStatus,
+                order.orderType,
+                GroupBy.list(
+                    Projections.constructor(OrderResponseDto.MenuDto.class,
+                        orderMenu.name,
+                        orderMenu.price,
+                        orderMenu.quantity
+                    )
+                )
+            )
+        )
+        .from(order)
+        .leftJoin(orderMenu).on(orderMenu.order.id.eq(order.id))
+        .where(getWhereConditions(memberId))
+        .offset(pageRequestDto.getFirstIndex())
+        .limit(pageRequestDto.getSize())
+        .orderBy(getOrderConditions(pageRequestDto))
+        .fetch();
+  }
+
+  /**
+   * 전체 데이터 수 조회
+   */
+  private long getTotalDataCount(Long memberId) {
+    return Optional.ofNullable(jpaQueryFactory
+            .select(order.count())
+            .from(order)
+            .where(getWhereConditions(memberId))
+            .fetchOne()
+        )
+        .orElse(0L);
+  }
+
+  /**
+   * 조회 조건
+   */
+  private BooleanBuilder getWhereConditions(Long memberId) {
+    BooleanBuilder builder = new BooleanBuilder();
+
+    return builder.and(order.deletedAt.isNull())
+        .and(order.member.id.eq(memberId));
+  }
+
+  /**
+   * 정렬 조건
+   */
+  private OrderSpecifier<?> getOrderConditions(PageRequestDto pageRequestDto) {
+    final String order = pageRequestDto.getOrder();
+
+    return switch (order) {
+      case "latest" -> QOrder.order.createdAt.desc();
+      case "earliest" -> QOrder.order.createdAt.asc();
+      default -> throw new CustomException(MenuErrorCode.ORDER_BY_NOT_FOUND);
+    };
+  }
+}

--- a/src/main/java/com/fourseason/delivery/domain/order/service/OrderCustomerService.java
+++ b/src/main/java/com/fourseason/delivery/domain/order/service/OrderCustomerService.java
@@ -68,7 +68,7 @@ public class OrderCustomerService {
     for (Menu menu : menuList) {
       OrderMenu orderMenu = OrderMenu.addOf(menu, menuDtoMap.get(menu.getId()).quantity());
 
-      totalPrice += orderMenu.getPrice();
+      totalPrice += orderMenu.getPrice() * orderMenu.getQuantity();
       orderMenuList.add(orderMenu);
     }
 

--- a/src/main/java/com/fourseason/delivery/domain/order/service/OrderCustomerService.java
+++ b/src/main/java/com/fourseason/delivery/domain/order/service/OrderCustomerService.java
@@ -10,9 +10,10 @@ import com.fourseason.delivery.domain.member.entity.Member;
 import com.fourseason.delivery.domain.member.repository.MemberRepository;
 import com.fourseason.delivery.domain.menu.entity.Menu;
 import com.fourseason.delivery.domain.menu.repository.MenuRepository;
-import com.fourseason.delivery.domain.order.dto.response.OrderResponseDto;
+import com.fourseason.delivery.domain.order.dto.response.OrderDetailResponseDto;
 import com.fourseason.delivery.domain.order.dto.request.CreateOrderRequestDto;
 import com.fourseason.delivery.domain.order.dto.request.CreateOrderRequestDto.MenuDto;
+import com.fourseason.delivery.domain.order.dto.response.OrderSummaryResponseDto;
 import com.fourseason.delivery.domain.order.entity.Order;
 import com.fourseason.delivery.domain.order.entity.OrderMenu;
 import com.fourseason.delivery.domain.order.repository.OrderRepository;
@@ -79,17 +80,17 @@ public class OrderCustomerService {
   }
 
   @Transactional(readOnly = true)
-  public OrderResponseDto getOrder(UUID orderId, Long memberId) {
+  public OrderDetailResponseDto getOrder(UUID orderId, Long memberId) {
     Order order = orderRepository.findById(orderId)
         .orElseThrow(() -> new CustomException(ORDER_NOT_FOUND));
 
     order.assertOrderedBy(memberId);
 
-    return OrderResponseDto.of(order);
+    return OrderDetailResponseDto.of(order);
   }
 
   @Transactional(readOnly = true)
-  public PageResponseDto<OrderResponseDto> getOrderList(
+  public PageResponseDto<OrderSummaryResponseDto> getOrderList(
       Long memberId,
       PageRequestDto pageRequestDto
   ) {

--- a/src/main/java/com/fourseason/delivery/domain/order/service/OrderCustomerService.java
+++ b/src/main/java/com/fourseason/delivery/domain/order/service/OrderCustomerService.java
@@ -53,7 +53,7 @@ public class OrderCustomerService {
         .orElseThrow(() -> new CustomException(SHOP_NOT_FOUND));
 
     List<UUID> requestMenuIds = request.menuList().stream().map(MenuDto::menuId).toList();
-    List<Menu> menuList = menuRepository.findByIdIn(requestMenuIds);
+    List<Menu> menuList = menuRepository.findByIdInAndDeletedAtIsNull(requestMenuIds);
 
     if (requestMenuIds.size() != menuList.size()) {
       throw new CustomException(MENU_NOT_FOUND);

--- a/src/main/java/com/fourseason/delivery/domain/order/service/OrderCustomerService.java
+++ b/src/main/java/com/fourseason/delivery/domain/order/service/OrderCustomerService.java
@@ -79,9 +79,11 @@ public class OrderCustomerService {
   }
 
   @Transactional(readOnly = true)
-  public OrderResponseDto getOrder(UUID orderId) {
+  public OrderResponseDto getOrder(UUID orderId, Long memberId) {
     Order order = orderRepository.findById(orderId)
         .orElseThrow(() -> new CustomException(ORDER_NOT_FOUND));
+
+    order.assertOrderedBy(memberId);
 
     return OrderResponseDto.of(order);
   }

--- a/src/main/java/com/fourseason/delivery/domain/order/service/OrderOwnerService.java
+++ b/src/main/java/com/fourseason/delivery/domain/order/service/OrderOwnerService.java
@@ -23,7 +23,8 @@ public class OrderOwnerService {
     Order order = orderRepository.findById(orderId).
         orElseThrow(() -> new CustomException(ORDER_NOT_FOUND));
 
-    order.validateShopOwner(ownerId);
+    order.assertShopOwner(ownerId);
+    order.assertOrderIsPending();
 
     order.updateStatus(ACCEPTED);
   }

--- a/src/test/java/com/fourseason/delivery/domain/order/service/OrderCustomerServiceTest.java
+++ b/src/test/java/com/fourseason/delivery/domain/order/service/OrderCustomerServiceTest.java
@@ -7,7 +7,6 @@ import static com.fourseason.delivery.domain.order.entity.OrderType.ONLINE;
 import static com.fourseason.delivery.domain.order.exception.OrderErrorCode.MEMBER_NOT_FOUND;
 import static com.fourseason.delivery.domain.order.exception.OrderErrorCode.ORDER_NOT_FOUND;
 import static com.fourseason.delivery.domain.shop.exception.ShopErrorCode.SHOP_NOT_FOUND;
-import static com.fourseason.delivery.fixture.MemberFixture.*;
 import static com.fourseason.delivery.fixture.MemberFixture.createMember;
 import static com.fourseason.delivery.fixture.OrderFixture.createOrder;
 import static com.fourseason.delivery.fixture.OrderMenuFixture.createOrderMenuList;
@@ -20,15 +19,14 @@ import static org.mockito.Mockito.when;
 import com.fourseason.delivery.domain.member.entity.Member;
 import com.fourseason.delivery.domain.member.repository.MemberRepository;
 import com.fourseason.delivery.domain.menu.repository.MenuRepository;
-import com.fourseason.delivery.domain.order.dto.response.OrderResponseDto;
 import com.fourseason.delivery.domain.order.dto.request.CreateOrderRequestDto;
 import com.fourseason.delivery.domain.order.dto.request.CreateOrderRequestDto.MenuDto;
+import com.fourseason.delivery.domain.order.dto.response.OrderDetailResponseDto;
 import com.fourseason.delivery.domain.order.entity.Order;
 import com.fourseason.delivery.domain.order.entity.OrderMenu;
 import com.fourseason.delivery.domain.order.repository.OrderRepository;
 import com.fourseason.delivery.domain.shop.entity.Shop;
 import com.fourseason.delivery.domain.shop.repository.ShopRepository;
-import com.fourseason.delivery.fixture.MemberFixture;
 import com.fourseason.delivery.global.exception.CustomException;
 import java.util.ArrayList;
 import java.util.List;
@@ -203,7 +201,8 @@ class OrderCustomerServiceTest {
       when(orderRepository.findById(order.getId())).thenReturn(Optional.of(order));
 
       // when
-      OrderResponseDto response = orderCustomerService.getOrder(order.getId(), loginMember.getId());
+      OrderDetailResponseDto response = orderCustomerService.getOrder(order.getId(),
+          loginMember.getId());
 
       // then
       assertThat(response.shopName()).isEqualTo(order.getShop().getName());

--- a/src/test/java/com/fourseason/delivery/domain/order/service/OrderCustomerServiceTest.java
+++ b/src/test/java/com/fourseason/delivery/domain/order/service/OrderCustomerServiceTest.java
@@ -129,7 +129,7 @@ class OrderCustomerServiceTest {
       when(memberRepository.findById(memberId)).thenReturn(Optional.of(member));
       when(shopRepository.findById(request.shopId())).thenReturn(
           Optional.of(shop));
-      when(menuRepository.findByIdIn(List.of(request.menuList().get(0).menuId())))
+      when(menuRepository.findByIdInAndDeletedAtIsNull(List.of(request.menuList().get(0).menuId())))
           .thenReturn(List.of());
 
       // when

--- a/src/test/java/com/fourseason/delivery/domain/order/service/OrderOwnerServiceTest.java
+++ b/src/test/java/com/fourseason/delivery/domain/order/service/OrderOwnerServiceTest.java
@@ -1,6 +1,10 @@
 package com.fourseason.delivery.domain.order.service;
 
+import static com.fourseason.delivery.domain.member.entity.Role.CUSTOMER;
+import static com.fourseason.delivery.domain.member.entity.Role.OWNER;
 import static com.fourseason.delivery.domain.order.entity.OrderStatus.ACCEPTED;
+import static com.fourseason.delivery.domain.order.entity.OrderStatus.PENDING;
+import static com.fourseason.delivery.domain.order.entity.OrderType.ONLINE;
 import static com.fourseason.delivery.domain.order.exception.OrderErrorCode.ORDER_NOT_FOUND;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -10,7 +14,11 @@ import com.fourseason.delivery.domain.member.entity.Member;
 import com.fourseason.delivery.domain.order.entity.Order;
 import com.fourseason.delivery.domain.order.repository.OrderRepository;
 import com.fourseason.delivery.domain.shop.entity.Shop;
+import com.fourseason.delivery.fixture.MemberFixture;
+import com.fourseason.delivery.fixture.OrderFixture;
+import com.fourseason.delivery.fixture.ShopFixture;
 import com.fourseason.delivery.global.exception.CustomException;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
@@ -20,7 +28,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.test.util.ReflectionTestUtils;
 
 @ExtendWith(MockitoExtension.class)
 class OrderOwnerServiceTest {
@@ -54,21 +61,15 @@ class OrderOwnerServiceTest {
     @Test
     @DisplayName("주문 수락 시 해당 가게의 주문이 아니면 예외가 발생한다.")
     void not_shop_order() {
+
       // given
-      Member owner = Member.builder().build();
-      ReflectionTestUtils.setField(owner, "id", ownerId);
+      Member another = MemberFixture.createMember(OWNER);
 
-      Long anotherId = 2L;
-      Member another = Member.builder().build();
-      ReflectionTestUtils.setField(another, "id", anotherId);
+      Shop anotherShop = ShopFixture.createShop(another);
 
-      Shop anotherShop = Shop.builder()
-          .member(another)
-          .build();
-
-      Order anotherOrder = Order.builder()
-          .shop(anotherShop)
-          .build();
+      Member orderMember = MemberFixture.createMember(CUSTOMER);
+      Order anotherOrder = OrderFixture.createOrder(
+          orderMember, anotherShop, PENDING, ONLINE, List.of());
 
       when(orderRepository.findById(orderId)).thenReturn(Optional.of(anotherOrder));
 
@@ -83,16 +84,10 @@ class OrderOwnerServiceTest {
     @DisplayName("주문 수락 성공")
     void success() {
       // given
-      Member owner = Member.builder().build();
-      ReflectionTestUtils.setField(owner, "id", ownerId);
-
-      Shop shop = Shop.builder()
-          .member(owner)
-          .build();
-
-      Order order = Order.builder()
-          .shop(shop)
-          .build();
+      Member owner = MemberFixture.createMember(OWNER);
+      Shop shop = ShopFixture.createShop(owner);
+      Member customer = MemberFixture.createMember(CUSTOMER);
+      Order order = OrderFixture.createOrder(customer, shop, PENDING, ONLINE, List.of());
 
       when(orderRepository.findById(orderId)).thenReturn(Optional.of(order));
 

--- a/src/test/java/com/fourseason/delivery/fixture/MemberFixture.java
+++ b/src/test/java/com/fourseason/delivery/fixture/MemberFixture.java
@@ -1,0 +1,24 @@
+package com.fourseason.delivery.fixture;
+
+import com.fourseason.delivery.domain.member.entity.Member;
+import com.fourseason.delivery.domain.member.entity.Role;
+import java.util.concurrent.atomic.AtomicLong;
+import org.springframework.test.util.ReflectionTestUtils;
+
+public class MemberFixture {
+
+  private static final AtomicLong idCounter = new AtomicLong(1);
+
+  public static long nextId() {
+    return idCounter.getAndIncrement();
+  }
+
+  public static Member createMember(Role role) {
+    Member member = Member.builder()
+        .role(role)
+        .build();
+
+    ReflectionTestUtils.setField(member, "id", nextId());
+    return member;
+  }
+}

--- a/src/test/java/com/fourseason/delivery/fixture/MenuFixture.java
+++ b/src/test/java/com/fourseason/delivery/fixture/MenuFixture.java
@@ -1,0 +1,34 @@
+package com.fourseason.delivery.fixture;
+
+import com.fourseason.delivery.domain.menu.entity.Menu;
+import com.fourseason.delivery.domain.shop.entity.Shop;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicLong;
+import org.springframework.test.util.ReflectionTestUtils;
+
+public class MenuFixture {
+
+  private static final AtomicLong counter = new AtomicLong(1);
+
+  public static UUID nextUUID() {
+    long count = counter.getAndIncrement();
+    return UUID.nameUUIDFromBytes(String.valueOf(count).getBytes(StandardCharsets.UTF_8));
+  }
+
+  public static Menu createMenu(Shop shop, String name, int price) {
+    Menu menu =
+        Menu.builder()
+            .shop(shop)
+            .name(name).price(price).build();
+
+    ReflectionTestUtils.setField(menu, "id", nextUUID());
+    return menu;
+  }
+
+  public static List<Menu> createMenuList(Menu... menus) {
+    return List.of(menus);
+  }
+
+}

--- a/src/test/java/com/fourseason/delivery/fixture/OrderFixture.java
+++ b/src/test/java/com/fourseason/delivery/fixture/OrderFixture.java
@@ -1,0 +1,46 @@
+package com.fourseason.delivery.fixture;
+
+import static com.fourseason.delivery.domain.member.entity.Role.*;
+
+import com.fourseason.delivery.domain.member.entity.Member;
+import com.fourseason.delivery.domain.order.entity.Order;
+import com.fourseason.delivery.domain.order.entity.OrderMenu;
+import com.fourseason.delivery.domain.order.entity.OrderStatus;
+import com.fourseason.delivery.domain.order.entity.OrderType;
+import com.fourseason.delivery.domain.shop.entity.Shop;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicLong;
+import org.springframework.test.util.ReflectionTestUtils;
+
+public class OrderFixture {
+
+  private static final AtomicLong counter = new AtomicLong(1);
+
+  public static UUID nextUUID() {
+    long count = counter.getAndIncrement();
+    return UUID.nameUUIDFromBytes(String.valueOf(count).getBytes(StandardCharsets.UTF_8));
+  }
+
+  public static Order createOrder(Member member, Shop shop, OrderStatus status, OrderType type, List<OrderMenu> orderMenuList) {
+    int totalPrice = 0;
+    for (OrderMenu orderMenu : orderMenuList) {
+      totalPrice += orderMenu.getPrice();
+    }
+
+    Order order = Order.builder()
+        .shop(shop)
+        .member(member)
+        .orderMenuList(orderMenuList)
+        .orderStatus(status)
+        .orderType(type)
+        .address("서울 어딘가")
+        .instruction("주문 요청 사항입니다.")
+        .totalPrice(totalPrice)
+        .build();
+
+    ReflectionTestUtils.setField(order, "id", nextUUID());
+    return order;
+  }
+}

--- a/src/test/java/com/fourseason/delivery/fixture/OrderMenuFixture.java
+++ b/src/test/java/com/fourseason/delivery/fixture/OrderMenuFixture.java
@@ -1,0 +1,30 @@
+package com.fourseason.delivery.fixture;
+
+import com.fourseason.delivery.domain.order.entity.OrderMenu;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicLong;
+import org.springframework.test.util.ReflectionTestUtils;
+
+public class OrderMenuFixture {
+
+  private static final AtomicLong counter = new AtomicLong(1);
+
+  public static UUID nextUUID() {
+    long count = counter.getAndIncrement();
+    return UUID.nameUUIDFromBytes(String.valueOf(count).getBytes(StandardCharsets.UTF_8));
+  }
+
+  public static OrderMenu createOrderMenuWithQuantity(String name, int price, int quantity) {
+    OrderMenu orderMenu =
+        OrderMenu.builder().name(name).price(price).quantity(quantity).build();
+
+    ReflectionTestUtils.setField(orderMenu, "id", nextUUID());
+    return orderMenu;
+  }
+
+  public static List<OrderMenu> createOrderMenuList(OrderMenu... orderMenus) {
+    return List.of(orderMenus);
+  }
+}

--- a/src/test/java/com/fourseason/delivery/fixture/ShopFixture.java
+++ b/src/test/java/com/fourseason/delivery/fixture/ShopFixture.java
@@ -1,0 +1,32 @@
+package com.fourseason.delivery.fixture;
+
+import com.fourseason.delivery.domain.member.entity.Member;
+import com.fourseason.delivery.domain.shop.entity.Shop;
+import java.nio.charset.StandardCharsets;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicLong;
+import org.springframework.test.util.ReflectionTestUtils;
+
+public class ShopFixture {
+
+  private static final AtomicLong counter = new AtomicLong(1);
+
+  public static UUID nextUUID() {
+    long count = counter.getAndIncrement();
+    return UUID.nameUUIDFromBytes(String.valueOf(count).getBytes(StandardCharsets.UTF_8));
+  }
+
+  public static Shop createShop(Member member) {
+    Shop shop = Shop.builder()
+        .name("가게 이름")
+        .description("가게 설명")
+        .tel("010-1234-5678")
+        .address("가게 주소")
+        .detailAddress("가게 상세 주소")
+        .member(member)
+        .build();
+
+    ReflectionTestUtils.setField(shop, "id", nextUUID());
+    return shop;
+  }
+}


### PR DESCRIPTION
## 요약

고객 주문 조회 API구현

## 작업 내용

- 고객 주문 조회 API 구현

## 참고 사항

- mock 테스트 중에 각 도메인별 mocking 하는 과정이 번거로워서 `Fixture`를 생성했습니다.
```java
Member member = Member.builder()
    .name()
    .password()
    .(...)
    .build()
// 빌더로 매번 테스트를 생성하는 것이 번거롭기도 하고 코드가 복잡합니다.

Member customer = MemberFixture.createMember(Role.CUSTOMER);
// 이처럼 간결하게 작성할 수 있도록 Fixture 클래스를 생성하였습니다.
```

- 고객 주문 리스트 조회 테스트는 시간 상 작성하지 못했습니다. API 완성을 위주로 진행하려고 합니다.
- http client 테스트로는 고객 주문 요청, 고객 주문 리스트 조회, Owner의 주문 수락 테스트를 완료하였습니다. Member와 Shop, Category, 이미지는 더미를 직접 insert 쿼리로 넣어주어서 진행하였습니다.
- 고객 주문 리스트 조회는 QueryDsl을 사용하였으나, 추후에 쿼리 개선이 필요해보입니다.

## 관련 이슈
#14 #17 