### PR TITLE
점주 주문 조회(단건, 목록) API 구현

### DIFF
--- a/http/order.http
+++ b/http/order.http
@@ -22,9 +22,17 @@ GET http://localhost:8080/api/customer/orders/adb6b9a4-77e5-4e77-a22f-61cd0f7a7f
 
 ### 고객 주문 리스트 조회
 GET http://localhost:8080/api/customer/orders?memberId=5&page=1&size=20&orderBy=latest
-Content-Type: application/json
 
-### 주문 수락
+### 점주 주문 수락
 POST http://localhost:8080/api/owner/orders/adb6b9a4-77e5-4e77-a22f-61cd0f7a7f39/accept?memberId=3
 Content-Type: application/json
+
+### 점주 주문 상세 조회
+GET http://localhost:8080/api/owner/orders/adb6b9a4-77e5-4e77-a22f-61cd0f7a7f39?memberId=3
+
+### 점주 주문 목록 조회
+GET http://localhost:8080/api/owner/orders?memberId=3&shopId=00000000-0000-0000-0000-000000000010&page=1&size=20&orderBy=latest
+
+### 점주 주문 목록 조회(shop 검색 조건 x)
+GET http://localhost:8080/api/owner/orders?memberId=3&page=1&size=20&orderBy=latest
 

--- a/src/main/java/com/fourseason/delivery/domain/order/controller/OrderOwnerController.java
+++ b/src/main/java/com/fourseason/delivery/domain/order/controller/OrderOwnerController.java
@@ -1,9 +1,16 @@
 package com.fourseason.delivery.domain.order.controller;
 
+import com.fourseason.delivery.domain.order.dto.response.OrderDetailResponseDto;
+import com.fourseason.delivery.domain.order.dto.response.OrderSummaryResponseDto;
+import com.fourseason.delivery.domain.order.dto.response.OwnerOrderDetailResponseDto;
+import com.fourseason.delivery.domain.order.dto.response.OwnerOrderSummaryResponseDto;
 import com.fourseason.delivery.domain.order.service.OrderOwnerService;
+import com.fourseason.delivery.global.dto.PageRequestDto;
+import com.fourseason.delivery.global.dto.PageResponseDto;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -28,5 +35,33 @@ public class OrderOwnerController {
   ) {
     orderOwnerService.acceptOrder(memberId, orderId);
     return ResponseEntity.ok().build();
+  }
+
+  /**
+   * 점주 주문 상세 조회 API
+   * 가게 주문을 상세 조회합니다.
+   */
+  @GetMapping("/{orderId}")
+  public ResponseEntity<OwnerOrderDetailResponseDto> getOrder(
+      @PathVariable UUID orderId,
+      @RequestParam Long memberId
+  ) {
+    return ResponseEntity.ok(orderOwnerService.getOrder(orderId, memberId));
+  }
+
+  /**
+   * 점주 주문 목록 조회 API
+   * 점주가 관리하는 가게들의 주문 목록을 조회합니다.
+   * @param shopId 가게로 필터링하기 위한 검색 조건
+   */
+  @GetMapping
+  public ResponseEntity<PageResponseDto<OwnerOrderSummaryResponseDto>> getOrderList(
+      @RequestParam Long memberId,
+      @RequestParam(required = false) UUID shopId,
+      @RequestParam(defaultValue = "1") int page,
+      @RequestParam(defaultValue = "10") int size,
+      @RequestParam(defaultValue = "latest") String orderBy) {
+    PageRequestDto pageRequestDto = PageRequestDto.of(page - 1, size, orderBy);
+    return ResponseEntity.ok(orderOwnerService.getOrderList(memberId, shopId, pageRequestDto));
   }
 }

--- a/src/main/java/com/fourseason/delivery/domain/order/dto/response/OwnerOrderDetailResponseDto.java
+++ b/src/main/java/com/fourseason/delivery/domain/order/dto/response/OwnerOrderDetailResponseDto.java
@@ -1,0 +1,75 @@
+package com.fourseason.delivery.domain.order.dto.response;
+
+import static java.util.stream.Collectors.toList;
+
+import com.fourseason.delivery.domain.order.entity.Order;
+import com.fourseason.delivery.domain.order.entity.OrderMenu;
+import com.fourseason.delivery.domain.order.entity.OrderStatus;
+import com.fourseason.delivery.domain.order.entity.OrderType;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.Builder;
+
+public record OwnerOrderDetailResponseDto(
+    String shopName,
+    String address,
+    String orderedUsername,
+    String instruction,
+    Integer totalPrice,
+    OrderStatus status,
+    OrderType type,
+    List<MenuDto> menuList,
+    LocalDateTime createdAt,
+    LocalDateTime updatedAt,
+    String updatedBy
+) {
+
+  public OwnerOrderDetailResponseDto(Order order) {
+    this(order.getShop().getName(),
+        order.getAddress(),
+        order.getMember().getUsername(),
+        order.getInstruction(),
+        order.getTotalPrice(),
+        order.getOrderStatus(),
+        order.getOrderType(),
+        order.getOrderMenuList().stream().map(MenuDto::of).collect(toList()),
+        order.getCreatedAt(),
+        order.getUpdatedAt(),
+        order.getUpdatedBy()
+    );
+  }
+
+  public static OwnerOrderDetailResponseDto of(Order order) {
+    return new OwnerOrderDetailResponseDto(
+        order.getShop().getName(),
+        order.getAddress(),
+        order.getMember().getUsername(),
+        order.getInstruction(),
+        order.getTotalPrice(),
+        order.getOrderStatus(),
+        order.getOrderType(),
+        order.getOrderMenuList().stream().map(MenuDto::of).collect(toList()),
+        order.getCreatedAt(),
+        order.getUpdatedAt(),
+        order.getUpdatedBy()
+    );
+  }
+
+  @Builder
+  public record MenuDto(
+      String name,
+      Integer price,
+      Integer quantity,
+      Integer totalPrice
+  ) {
+
+    public static MenuDto of(OrderMenu orderMenu) {
+      return MenuDto.builder()
+          .name(orderMenu.getName())
+          .price(orderMenu.getPrice())
+          .quantity(orderMenu.getQuantity())
+          .totalPrice(orderMenu.getPrice() * orderMenu.getQuantity())
+          .build();
+    }
+  }
+}

--- a/src/main/java/com/fourseason/delivery/domain/order/dto/response/OwnerOrderDetailResponseDto.java
+++ b/src/main/java/com/fourseason/delivery/domain/order/dto/response/OwnerOrderDetailResponseDto.java
@@ -32,7 +32,7 @@ public record OwnerOrderDetailResponseDto(
         order.getTotalPrice(),
         order.getOrderStatus(),
         order.getOrderType(),
-        order.getOrderMenuList().stream().map(MenuDto::of).collect(toList()),
+        order.getOrderMenuList().stream().map(MenuDto::of).toList(),
         order.getCreatedAt(),
         order.getUpdatedAt(),
         order.getUpdatedBy()
@@ -48,7 +48,7 @@ public record OwnerOrderDetailResponseDto(
         order.getTotalPrice(),
         order.getOrderStatus(),
         order.getOrderType(),
-        order.getOrderMenuList().stream().map(MenuDto::of).collect(toList()),
+        order.getOrderMenuList().stream().map(MenuDto::of).toList(),
         order.getCreatedAt(),
         order.getUpdatedAt(),
         order.getUpdatedBy()

--- a/src/main/java/com/fourseason/delivery/domain/order/dto/response/OwnerOrderSummaryResponseDto.java
+++ b/src/main/java/com/fourseason/delivery/domain/order/dto/response/OwnerOrderSummaryResponseDto.java
@@ -1,0 +1,66 @@
+package com.fourseason.delivery.domain.order.dto.response;
+
+import static java.util.stream.Collectors.toList;
+
+import com.fourseason.delivery.domain.order.entity.Order;
+import com.fourseason.delivery.domain.order.entity.OrderMenu;
+import com.fourseason.delivery.domain.order.entity.OrderStatus;
+import com.querydsl.core.annotations.QueryProjection;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.Builder;
+
+public record OwnerOrderSummaryResponseDto(
+    String shopName,
+    String address,
+    String orderedUsername,
+    Integer totalPrice,
+    OrderStatus status,
+    List<MenuDto> menuList,
+    LocalDateTime createdAt,
+    LocalDateTime updatedAt,
+    String updatedBy
+) {
+
+  @QueryProjection
+  public OwnerOrderSummaryResponseDto(Order order) {
+    this(order.getShop().getName(),
+        order.getAddress(),
+        order.getMember().getUsername(),
+        order.getTotalPrice(),
+        order.getOrderStatus(),
+        order.getOrderMenuList().stream().map(MenuDto::of).collect(toList()),
+        order.getCreatedAt(),
+        order.getUpdatedAt(),
+        order.getUpdatedBy()
+    );
+  }
+
+  public static OwnerOrderSummaryResponseDto of(Order order) {
+    return new OwnerOrderSummaryResponseDto(
+        order.getShop().getName(),
+        order.getAddress(),
+        order.getMember().getUsername(),
+        order.getTotalPrice(),
+        order.getOrderStatus(),
+        order.getOrderMenuList().stream().map(MenuDto::of).collect(toList()),
+        order.getCreatedAt(),
+        order.getUpdatedAt(),
+        order.getUpdatedBy()
+    );
+  }
+
+  @Builder
+  public record MenuDto(
+      String name,
+      Integer quantity
+  ) {
+
+    public static MenuDto of(OrderMenu orderMenu) {
+      return MenuDto.builder()
+          .name(orderMenu.getName())
+          .quantity(orderMenu.getQuantity())
+          .build();
+    }
+  }
+}

--- a/src/main/java/com/fourseason/delivery/domain/order/dto/response/OwnerOrderSummaryResponseDto.java
+++ b/src/main/java/com/fourseason/delivery/domain/order/dto/response/OwnerOrderSummaryResponseDto.java
@@ -29,7 +29,7 @@ public record OwnerOrderSummaryResponseDto(
         order.getMember().getUsername(),
         order.getTotalPrice(),
         order.getOrderStatus(),
-        order.getOrderMenuList().stream().map(MenuDto::of).collect(toList()),
+        order.getOrderMenuList().stream().map(MenuDto::of).toList(),
         order.getCreatedAt(),
         order.getUpdatedAt(),
         order.getUpdatedBy()
@@ -43,7 +43,7 @@ public record OwnerOrderSummaryResponseDto(
         order.getMember().getUsername(),
         order.getTotalPrice(),
         order.getOrderStatus(),
-        order.getOrderMenuList().stream().map(MenuDto::of).collect(toList()),
+        order.getOrderMenuList().stream().map(MenuDto::of).toList(),
         order.getCreatedAt(),
         order.getUpdatedAt(),
         order.getUpdatedBy()

--- a/src/main/java/com/fourseason/delivery/domain/order/exception/OrderErrorCode.java
+++ b/src/main/java/com/fourseason/delivery/domain/order/exception/OrderErrorCode.java
@@ -11,6 +11,7 @@ public enum OrderErrorCode implements ErrorCode {
   NOT_SHOP_OWNER(HttpStatus.BAD_REQUEST, "가게 주인이 아닙니다."),
   NOT_PENDING_ORDER(HttpStatus.BAD_REQUEST, "보류 중인 주문이 아닙니다."),
   NOT_ORDERED_BY_CUSTOMER(HttpStatus.BAD_REQUEST, "해당 주문을 요청한 고객이 아닙니다."),
+  ORDER_BY_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 정렬을 찾을 수 없습니다."),
 
   // TODO: 각 도메인 ErrorCode 로 옮기기,
   MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 회원을 찾을 수 없습니다."),

--- a/src/main/java/com/fourseason/delivery/domain/order/repository/OwnerOrderRepositoryCustom.java
+++ b/src/main/java/com/fourseason/delivery/domain/order/repository/OwnerOrderRepositoryCustom.java
@@ -1,0 +1,102 @@
+package com.fourseason.delivery.domain.order.repository;
+
+import static com.fourseason.delivery.domain.order.entity.QOrder.order;
+
+import com.fourseason.delivery.domain.menu.exception.MenuErrorCode;
+import com.fourseason.delivery.domain.order.dto.response.OrderSummaryResponseDto;
+import com.fourseason.delivery.domain.order.dto.response.OwnerOrderSummaryResponseDto;
+import com.fourseason.delivery.domain.order.dto.response.QOrderSummaryResponseDto;
+import com.fourseason.delivery.domain.order.dto.response.QOwnerOrderSummaryResponseDto;
+import com.fourseason.delivery.domain.order.entity.QOrder;
+import com.fourseason.delivery.global.dto.PageRequestDto;
+import com.fourseason.delivery.global.dto.PageResponseDto;
+import com.fourseason.delivery.global.exception.CustomException;
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class OwnerOrderRepositoryCustom {
+
+  private final JPAQueryFactory jpaQueryFactory;
+
+  /**
+   * 가게 주문 목록 조회
+   */
+  public PageResponseDto<OwnerOrderSummaryResponseDto> findOrderListWithPage(
+      Long memberId,
+      UUID shopId,
+      PageRequestDto pageRequestDto
+  ) {
+    List<OwnerOrderSummaryResponseDto> content = getOrderList(memberId, shopId, pageRequestDto);
+    long total = getTotalDataCount(memberId, shopId);
+
+    return new PageResponseDto<>(content, total);
+  }
+
+  /**
+   * 페이징 결과 조회 메서드
+   */
+  private List<OwnerOrderSummaryResponseDto> getOrderList(
+      Long memberId,
+      UUID shopId,
+      PageRequestDto pageRequestDto
+  ) {
+    JPAQuery<OwnerOrderSummaryResponseDto> query = jpaQueryFactory
+        .select(new QOwnerOrderSummaryResponseDto(order))
+        .from(order)
+        .where(getWhereConditions(memberId, shopId))
+        .offset(pageRequestDto.getFirstIndex())
+        .limit(pageRequestDto.getSize())
+        .orderBy(getOrderConditions(pageRequestDto));
+
+    return query.fetch();
+  }
+
+  /**
+   * 전체 데이터 수 조회
+   */
+  private long getTotalDataCount(Long memberId, UUID shopId) {
+    return Optional.ofNullable(jpaQueryFactory
+            .select(order.count())
+            .from(order)
+            .where(getWhereConditions(memberId, shopId))
+            .fetchOne()
+        )
+        .orElse(0L);
+  }
+
+  /**
+   * 조회 조건
+   */
+  private BooleanBuilder getWhereConditions(Long memberId, UUID shopId) {
+    BooleanBuilder builder = new BooleanBuilder();
+
+    if (shopId != null) {
+      builder.and(order.shop.id.eq(shopId));
+    }
+
+    return builder.and(order.deletedAt.isNull())
+        .and(order.shop.member.id.eq(memberId));
+  }
+
+  /**
+   * 정렬 조건
+   */
+  private OrderSpecifier<?> getOrderConditions(PageRequestDto pageRequestDto) {
+    final String order = pageRequestDto.getOrder();
+
+    return switch (order) {
+      case "latest" -> QOrder.order.createdAt.desc();
+      case "earliest" -> QOrder.order.createdAt.asc();
+      default -> throw new CustomException(MenuErrorCode.ORDER_BY_NOT_FOUND);
+    };
+  }
+}

--- a/src/main/java/com/fourseason/delivery/domain/order/repository/OwnerOrderRepositoryCustom.java
+++ b/src/main/java/com/fourseason/delivery/domain/order/repository/OwnerOrderRepositoryCustom.java
@@ -8,6 +8,7 @@ import com.fourseason.delivery.domain.order.dto.response.OwnerOrderSummaryRespon
 import com.fourseason.delivery.domain.order.dto.response.QOrderSummaryResponseDto;
 import com.fourseason.delivery.domain.order.dto.response.QOwnerOrderSummaryResponseDto;
 import com.fourseason.delivery.domain.order.entity.QOrder;
+import com.fourseason.delivery.domain.order.exception.OrderErrorCode;
 import com.fourseason.delivery.global.dto.PageRequestDto;
 import com.fourseason.delivery.global.dto.PageResponseDto;
 import com.fourseason.delivery.global.exception.CustomException;
@@ -96,7 +97,7 @@ public class OwnerOrderRepositoryCustom {
     return switch (order) {
       case "latest" -> QOrder.order.createdAt.desc();
       case "earliest" -> QOrder.order.createdAt.asc();
-      default -> throw new CustomException(MenuErrorCode.ORDER_BY_NOT_FOUND);
+      default -> throw new CustomException(OrderErrorCode.ORDER_BY_NOT_FOUND);
     };
   }
 }

--- a/src/main/java/com/fourseason/delivery/domain/order/service/OrderOwnerService.java
+++ b/src/main/java/com/fourseason/delivery/domain/order/service/OrderOwnerService.java
@@ -3,8 +3,13 @@ package com.fourseason.delivery.domain.order.service;
 import static com.fourseason.delivery.domain.order.entity.OrderStatus.ACCEPTED;
 import static com.fourseason.delivery.domain.order.exception.OrderErrorCode.ORDER_NOT_FOUND;
 
+import com.fourseason.delivery.domain.order.dto.response.OwnerOrderDetailResponseDto;
+import com.fourseason.delivery.domain.order.dto.response.OwnerOrderSummaryResponseDto;
 import com.fourseason.delivery.domain.order.entity.Order;
 import com.fourseason.delivery.domain.order.repository.OrderRepository;
+import com.fourseason.delivery.domain.order.repository.OwnerOrderRepositoryCustom;
+import com.fourseason.delivery.global.dto.PageRequestDto;
+import com.fourseason.delivery.global.dto.PageResponseDto;
 import com.fourseason.delivery.global.exception.CustomException;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -16,6 +21,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class OrderOwnerService {
 
   private final OrderRepository orderRepository;
+  private final OwnerOrderRepositoryCustom ownerOrderRepositoryCustom;
 
   @Transactional
   public void acceptOrder(Long ownerId, UUID orderId) {
@@ -27,5 +33,24 @@ public class OrderOwnerService {
     order.assertOrderIsPending();
 
     order.updateStatus(ACCEPTED);
+  }
+
+  @Transactional(readOnly = true)
+  public OwnerOrderDetailResponseDto getOrder(UUID orderId, Long memberId) {
+    Order order = orderRepository.findById(orderId)
+        .orElseThrow(() -> new CustomException(ORDER_NOT_FOUND));
+
+    order.assertShopOwner(memberId);
+
+    return OwnerOrderDetailResponseDto.of(order);
+  }
+
+  @Transactional(readOnly = true)
+  public PageResponseDto<OwnerOrderSummaryResponseDto> getOrderList(
+      Long memberId,
+      UUID shopId,
+      PageRequestDto pageRequestDto
+  ) {
+    return ownerOrderRepositoryCustom.findOrderListWithPage(memberId, shopId, pageRequestDto);
   }
 }

--- a/src/test/java/com/fourseason/delivery/domain/order/service/OrderOwnerServiceTest.java
+++ b/src/test/java/com/fourseason/delivery/domain/order/service/OrderOwnerServiceTest.java
@@ -6,12 +6,20 @@ import static com.fourseason.delivery.domain.order.entity.OrderStatus.ACCEPTED;
 import static com.fourseason.delivery.domain.order.entity.OrderStatus.PENDING;
 import static com.fourseason.delivery.domain.order.entity.OrderType.ONLINE;
 import static com.fourseason.delivery.domain.order.exception.OrderErrorCode.ORDER_NOT_FOUND;
+import static com.fourseason.delivery.fixture.MemberFixture.createMember;
+import static com.fourseason.delivery.fixture.OrderFixture.createOrder;
+import static com.fourseason.delivery.fixture.OrderMenuFixture.createOrderMenuList;
+import static com.fourseason.delivery.fixture.OrderMenuFixture.createOrderMenuWithQuantity;
+import static com.fourseason.delivery.fixture.ShopFixture.createShop;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.when;
 
 import com.fourseason.delivery.domain.member.entity.Member;
+import com.fourseason.delivery.domain.order.dto.response.OrderDetailResponseDto;
+import com.fourseason.delivery.domain.order.dto.response.OwnerOrderDetailResponseDto;
 import com.fourseason.delivery.domain.order.entity.Order;
+import com.fourseason.delivery.domain.order.entity.OrderMenu;
 import com.fourseason.delivery.domain.order.repository.OrderRepository;
 import com.fourseason.delivery.domain.shop.entity.Shop;
 import com.fourseason.delivery.fixture.MemberFixture;
@@ -97,4 +105,86 @@ class OrderOwnerServiceTest {
       assertThat(order.getOrderStatus()).isEqualTo(ACCEPTED);
     }
   }
+
+  @Nested
+  class getOrder {
+
+    @Test
+    @DisplayName("점주 주문 상세 조회 시, 존재하지 않는 주문이면 예외가 발생한다.")
+    void order_not_found() {
+      // given
+      Member loginMember = createMember(OWNER);
+      UUID orderId = UUID.randomUUID();
+      when(orderRepository.findById(orderId)).thenThrow(new CustomException(ORDER_NOT_FOUND));
+
+      // when
+      // then
+      assertThatThrownBy(() -> orderOwnerService.getOrder(orderId, loginMember.getId()))
+          .isInstanceOf(CustomException.class)
+          .hasMessage("해당 주문을 찾을 수 없습니다.");
+    }
+
+    @Test
+    @DisplayName("점주 주문 상세 조회 시, 주문 가게의 점주가 아니면 예외가 발생한다.")
+    void not_ordered_by_customer() {
+      // given
+      Member loginMember = createMember(OWNER);
+
+      Member anotherOwner = createMember(OWNER);
+      Shop anotherOwnerShop = createShop(anotherOwner);
+      List<OrderMenu> orderMenuList = createOrderMenuList(
+          createOrderMenuWithQuantity("치킨", 5000, 1),
+          createOrderMenuWithQuantity("피자", 10000, 2),
+          createOrderMenuWithQuantity("족발", 20000, 3)
+      );
+
+      Member customer = createMember(CUSTOMER);
+      Order order = createOrder(customer, anotherOwnerShop, PENDING, ONLINE, orderMenuList);
+      when(orderRepository.findById(order.getId())).thenReturn(Optional.of(order));
+
+      // when
+      // then
+      assertThatThrownBy(() -> orderOwnerService.getOrder(order.getId(), loginMember.getId()))
+          .isInstanceOf(CustomException.class)
+          .hasMessage("가게 주인이 아닙니다.");
+    }
+
+    @Test
+    @DisplayName("점주 주문 상세 조회 성공")
+    void success() {
+      // given
+      Member loginMember = createMember(OWNER);
+
+      Shop shop = createShop(loginMember);
+      List<OrderMenu> orderMenuList = createOrderMenuList(
+          createOrderMenuWithQuantity("치킨", 5000, 1),
+          createOrderMenuWithQuantity("피자", 10000, 2),
+          createOrderMenuWithQuantity("족발", 20000, 3)
+      );
+
+      Order order = createOrder(loginMember, shop, PENDING, ONLINE, orderMenuList);
+      when(orderRepository.findById(order.getId())).thenReturn(Optional.of(order));
+
+      // when
+      OwnerOrderDetailResponseDto response = orderOwnerService.getOrder(order.getId(),
+          loginMember.getId());
+
+      // then
+      assertThat(response.shopName()).isEqualTo(order.getShop().getName());
+      assertThat(response.address()).isEqualTo(order.getAddress());
+      assertThat(response.orderedUsername()).isEqualTo(order.getMember().getUsername());
+      assertThat(response.instruction()).isEqualTo(order.getInstruction());
+      assertThat(response.totalPrice()).isEqualTo(order.getTotalPrice());
+      assertThat(response.status()).isEqualTo(PENDING);
+      assertThat(response.type()).isEqualTo(ONLINE);
+      assertThat(response.menuList().get(0).name()).isEqualTo(
+          order.getOrderMenuList().get(0).getName());
+      assertThat(response.menuList().get(0).price()).isEqualTo(
+          order.getOrderMenuList().get(0).getPrice());
+      assertThat(response.menuList().get(0).quantity()).isEqualTo(
+          order.getOrderMenuList().get(0).getQuantity());
+    }
+  }
+
+  // TODO: getOrderList Test 작성
 }


### PR DESCRIPTION
## 요약

점주 주문 조회(단건, 목록) API 구현

## 작업 내용

- 점주 주문 조회(단건, 목록) API 구현
- 점주의 주문 목록 조회가 의미하는 바는 '점주에게 요청된 주문 목록'입니다.
- 점주와 Shop의 관계는 1:N 이기 때문에 가게 별로 요청된 주문 목록을 볼 수 있도록 `shop_id`도 검색 조건에 추가하였습니다.

## 참고 사항

- 서비스의 단건 조회 메서드에 대해서만 단위 테스트를 완료하였습니다.
- 주문 목록 조회는 http 테스트로 진행하였습니다.

## 관련 이슈
#22 