### PR TITLE
고객 주문 취소, 삭제 API 구현

### DIFF
--- a/http/order.http
+++ b/http/order.http
@@ -18,14 +18,19 @@ Content-Type: application/json
 }
 
 ### 고객 주문 상세 조회
-GET http://localhost:8080/api/customer/orders/adb6b9a4-77e5-4e77-a22f-61cd0f7a7f39?memberId=5
+GET http://localhost:8080/api/customer/orders/eb638b55-89d9-42de-9a6d-2426c6c31355?memberId=5
 
 ### 고객 주문 리스트 조회
 GET http://localhost:8080/api/customer/orders?memberId=5&page=1&size=20&orderBy=latest
 
+### 고객 주문 취소
+POST http://localhost:8080/api/customer/orders/eb638b55-89d9-42de-9a6d-2426c6c31355/cancel?memberId=5
+
+### 고객 주문 내역 삭제
+DELETE http://localhost:8080/api/customer/orders/ff7c17be-c6dd-4841-9984-7989878ed842?memberId=5
+
 ### 점주 주문 수락
 POST http://localhost:8080/api/owner/orders/adb6b9a4-77e5-4e77-a22f-61cd0f7a7f39/accept?memberId=3
-Content-Type: application/json
 
 ### 점주 주문 상세 조회
 GET http://localhost:8080/api/owner/orders/adb6b9a4-77e5-4e77-a22f-61cd0f7a7f39?memberId=3

--- a/src/main/java/com/fourseason/delivery/domain/order/controller/OrderCustomerController.java
+++ b/src/main/java/com/fourseason/delivery/domain/order/controller/OrderCustomerController.java
@@ -10,6 +10,7 @@ import jakarta.validation.Valid;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -63,5 +64,29 @@ public class OrderCustomerController {
       @RequestParam(defaultValue = "latest") String orderBy) {
     PageRequestDto pageRequestDto = PageRequestDto.of(page - 1, size, orderBy);
     return ResponseEntity.ok(orderCustomerService.getOrderList(memberId, pageRequestDto));
+  }
+
+  /**
+   * 고객 주문 취소 API role: CUSTOMER
+   */
+  @PostMapping("/{orderId}/cancel")
+  public ResponseEntity<Void> cancelOrder(
+      @PathVariable UUID orderId,
+      @RequestParam Long memberId
+  ) {
+    orderCustomerService.cancelOrder(orderId, memberId);
+    return ResponseEntity.ok().build();
+  }
+
+  /**
+   * 고객 주문 삭제 API role: CUSTOMER
+   */
+  @DeleteMapping("/{orderId}")
+  public ResponseEntity<Void> deleteOrder(
+      @PathVariable UUID orderId,
+      @RequestParam Long memberId
+  ) {
+    orderCustomerService.deleteOrder(orderId, memberId);
+    return ResponseEntity.ok().build();
   }
 }

--- a/src/main/java/com/fourseason/delivery/domain/order/exception/OrderErrorCode.java
+++ b/src/main/java/com/fourseason/delivery/domain/order/exception/OrderErrorCode.java
@@ -12,6 +12,8 @@ public enum OrderErrorCode implements ErrorCode {
   NOT_PENDING_ORDER(HttpStatus.BAD_REQUEST, "보류 중인 주문이 아닙니다."),
   NOT_ORDERED_BY_CUSTOMER(HttpStatus.BAD_REQUEST, "해당 주문을 요청한 고객이 아닙니다."),
   ORDER_BY_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 정렬을 찾을 수 없습니다."),
+  ALREADY_CANCELED_ORDER(HttpStatus.BAD_REQUEST, "이미 취소된 주문입니다."),
+  ORDER_CANCEL_EXPIRED(HttpStatus.BAD_REQUEST, "주문 취소 기간이 만료되었습니다."),
 
   // TODO: 각 도메인 ErrorCode 로 옮기기,
   MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 회원을 찾을 수 없습니다."),

--- a/src/test/java/com/fourseason/delivery/domain/order/service/OrderCustomerServiceTest.java
+++ b/src/test/java/com/fourseason/delivery/domain/order/service/OrderCustomerServiceTest.java
@@ -2,12 +2,14 @@ package com.fourseason.delivery.domain.order.service;
 
 import static com.fourseason.delivery.domain.member.entity.Role.CUSTOMER;
 import static com.fourseason.delivery.domain.member.entity.Role.OWNER;
+import static com.fourseason.delivery.domain.order.entity.OrderStatus.CANCELED;
 import static com.fourseason.delivery.domain.order.entity.OrderStatus.PENDING;
 import static com.fourseason.delivery.domain.order.entity.OrderType.ONLINE;
 import static com.fourseason.delivery.domain.order.exception.OrderErrorCode.MEMBER_NOT_FOUND;
 import static com.fourseason.delivery.domain.order.exception.OrderErrorCode.ORDER_NOT_FOUND;
 import static com.fourseason.delivery.domain.shop.exception.ShopErrorCode.SHOP_NOT_FOUND;
 import static com.fourseason.delivery.fixture.MemberFixture.createMember;
+import static com.fourseason.delivery.fixture.OrderFixture.createExpiredOrder;
 import static com.fourseason.delivery.fixture.OrderFixture.createOrder;
 import static com.fourseason.delivery.fixture.OrderMenuFixture.createOrderMenuList;
 import static com.fourseason.delivery.fixture.OrderMenuFixture.createOrderMenuWithQuantity;
@@ -217,6 +219,199 @@ class OrderCustomerServiceTest {
           order.getOrderMenuList().get(0).getPrice());
       assertThat(response.menuList().get(0).quantity()).isEqualTo(
           order.getOrderMenuList().get(0).getQuantity());
+    }
+  }
+
+  @Nested
+  class CancelOrder {
+
+    @Test
+    @DisplayName("고객이 주문 취소 시, 존재하지 않는 주문이면 예외가 발생한다.")
+    void order_not_found() {
+      // given
+      Member loginMember = createMember(CUSTOMER);
+      UUID orderId = UUID.randomUUID();
+      when(orderRepository.findById(orderId)).thenThrow(new CustomException(ORDER_NOT_FOUND));
+
+      // when
+      // then
+      assertThatThrownBy(() -> orderCustomerService.cancelOrder(orderId, loginMember.getId()))
+          .isInstanceOf(CustomException.class)
+          .hasMessage("해당 주문을 찾을 수 없습니다.");
+    }
+
+    @Test
+    @DisplayName("고객이 주문 취소 시, 해당 주문을 요청한 고객이 아니면 예외가 발생한다.")
+    void not_ordered_by_customer() {
+      // given
+      Member loginMember = createMember(CUSTOMER);
+
+      Member owner = createMember(OWNER);
+      Shop shop = createShop(owner);
+      List<OrderMenu> orderMenuList = createOrderMenuList(
+          createOrderMenuWithQuantity("치킨", 5000, 1),
+          createOrderMenuWithQuantity("피자", 10000, 2),
+          createOrderMenuWithQuantity("족발", 20000, 3)
+      );
+
+      Member another = createMember(CUSTOMER);
+      Order order = createOrder(another, shop, PENDING, ONLINE, orderMenuList);
+      when(orderRepository.findById(order.getId())).thenReturn(Optional.of(order));
+
+      // when
+      // then
+      assertThatThrownBy(() -> orderCustomerService.cancelOrder(order.getId(), loginMember.getId()))
+          .isInstanceOf(CustomException.class)
+          .hasMessage("해당 주문을 요청한 고객이 아닙니다.");
+    }
+
+    @Test
+    @DisplayName("고객이 주문 취소 시, 이미 취소한 주문이면 예외가 발생한다.")
+    void already_canceled_order() {
+      // given
+      Member loginMember = createMember(CUSTOMER);
+
+      Member owner = createMember(OWNER);
+      Shop shop = createShop(owner);
+      List<OrderMenu> orderMenuList = createOrderMenuList(
+          createOrderMenuWithQuantity("치킨", 5000, 1),
+          createOrderMenuWithQuantity("피자", 10000, 2),
+          createOrderMenuWithQuantity("족발", 20000, 3)
+      );
+
+      Order canceledOrder = createOrder(loginMember, shop, CANCELED, ONLINE, orderMenuList);
+      when(orderRepository.findById(canceledOrder.getId())).thenReturn(Optional.of(canceledOrder));
+
+      // when
+      // then
+      assertThatThrownBy(
+          () -> orderCustomerService.cancelOrder(canceledOrder.getId(), loginMember.getId()))
+          .isInstanceOf(CustomException.class)
+          .hasMessage("이미 취소된 주문입니다.");
+    }
+
+    @Test
+    @DisplayName("고객이 주문 취소 시, 주문 취소 기간이 지났으면 예외가 발생한다.")
+    void order_cancel_expired() {
+      // given
+      Member loginMember = createMember(CUSTOMER);
+
+      Member owner = createMember(OWNER);
+      Shop shop = createShop(owner);
+      List<OrderMenu> orderMenuList = createOrderMenuList(
+          createOrderMenuWithQuantity("치킨", 5000, 1),
+          createOrderMenuWithQuantity("피자", 10000, 2),
+          createOrderMenuWithQuantity("족발", 20000, 3)
+      );
+
+      Order order = createExpiredOrder(loginMember, shop, PENDING, ONLINE, orderMenuList);
+
+      when(orderRepository.findById(order.getId())).thenReturn(Optional.of(order));
+
+      // when
+      // then
+      assertThatThrownBy(() -> orderCustomerService.cancelOrder(order.getId(), loginMember.getId()))
+          .isInstanceOf(CustomException.class)
+          .hasMessage("주문 취소 기간이 만료되었습니다.");
+    }
+
+    @Test
+    @DisplayName("고객의 요청 주문 취소 성공")
+    void success() {
+      // given
+      Member loginMember = createMember(CUSTOMER);
+
+      Member owner = createMember(OWNER);
+      Shop shop = createShop(owner);
+      List<OrderMenu> orderMenuList = createOrderMenuList(
+          createOrderMenuWithQuantity("치킨", 5000, 1),
+          createOrderMenuWithQuantity("피자", 10000, 2),
+          createOrderMenuWithQuantity("족발", 20000, 3)
+      );
+
+      Order order = createOrder(loginMember, shop, PENDING, ONLINE, orderMenuList);
+
+      when(orderRepository.findById(order.getId())).thenReturn(Optional.of(order));
+
+      // when
+      orderCustomerService.cancelOrder(order.getId(), loginMember.getId());
+
+      // then
+      assertThat(order.getOrderStatus()).isEqualTo(CANCELED);
+    }
+  }
+
+  @Nested
+  class DeleteOrder {
+
+    @Test
+    @DisplayName("고객이 주문 삭제 시, 존재하지 않는 주문이면 예외가 발생한다.")
+    void order_not_found() {
+      // given
+      Member loginMember = createMember(CUSTOMER);
+      when(memberRepository.findById(loginMember.getId())).thenReturn(Optional.of(loginMember));
+
+      UUID orderId = UUID.randomUUID();
+      when(orderRepository.findById(orderId)).thenThrow(new CustomException(ORDER_NOT_FOUND));
+
+      // when
+      // then
+      assertThatThrownBy(() -> orderCustomerService.deleteOrder(orderId, loginMember.getId()))
+          .isInstanceOf(CustomException.class)
+          .hasMessage("해당 주문을 찾을 수 없습니다.");
+    }
+
+    @Test
+    @DisplayName("고객이 주문 삭제 시, 해당 주문을 요청한 고객이 아니면 예외가 발생한다.")
+    void not_ordered_by_customer() {
+      // given
+      Member loginMember = createMember(CUSTOMER);
+      when(memberRepository.findById(loginMember.getId())).thenReturn(Optional.of(loginMember));
+
+      Member owner = createMember(OWNER);
+      Shop shop = createShop(owner);
+      List<OrderMenu> orderMenuList = createOrderMenuList(
+          createOrderMenuWithQuantity("치킨", 5000, 1),
+          createOrderMenuWithQuantity("피자", 10000, 2),
+          createOrderMenuWithQuantity("족발", 20000, 3)
+      );
+
+      Member another = createMember(CUSTOMER);
+      Order order = createOrder(another, shop, PENDING, ONLINE, orderMenuList);
+      when(orderRepository.findById(order.getId())).thenReturn(Optional.of(order));
+
+      // when
+      // then
+      assertThatThrownBy(() -> orderCustomerService.deleteOrder(order.getId(), loginMember.getId()))
+          .isInstanceOf(CustomException.class)
+          .hasMessage("해당 주문을 요청한 고객이 아닙니다.");
+    }
+
+    @Test
+    @DisplayName("고객의 주문 삭제 성공")
+    void success() {
+      // given
+      Member loginMember = createMember(CUSTOMER);
+      when(memberRepository.findById(loginMember.getId())).thenReturn(Optional.of(loginMember));
+
+      Member owner = createMember(OWNER);
+      Shop shop = createShop(owner);
+      List<OrderMenu> orderMenuList = createOrderMenuList(
+          createOrderMenuWithQuantity("치킨", 5000, 1),
+          createOrderMenuWithQuantity("피자", 10000, 2),
+          createOrderMenuWithQuantity("족발", 20000, 3)
+      );
+
+      Order order = createOrder(loginMember, shop, PENDING, ONLINE, orderMenuList);
+
+      when(orderRepository.findById(order.getId())).thenReturn(Optional.of(order));
+
+      // when
+      orderCustomerService.deleteOrder(order.getId(), loginMember.getId());
+
+      // then
+      assertThat(order.getDeletedAt()).isNotNull();
+      assertThat(order.getDeletedBy()).isEqualTo(loginMember.getUsername());
     }
   }
 }

--- a/src/test/java/com/fourseason/delivery/fixture/OrderFixture.java
+++ b/src/test/java/com/fourseason/delivery/fixture/OrderFixture.java
@@ -1,7 +1,5 @@
 package com.fourseason.delivery.fixture;
 
-import static com.fourseason.delivery.domain.member.entity.Role.*;
-
 import com.fourseason.delivery.domain.member.entity.Member;
 import com.fourseason.delivery.domain.order.entity.Order;
 import com.fourseason.delivery.domain.order.entity.OrderMenu;
@@ -9,6 +7,7 @@ import com.fourseason.delivery.domain.order.entity.OrderStatus;
 import com.fourseason.delivery.domain.order.entity.OrderType;
 import com.fourseason.delivery.domain.shop.entity.Shop;
 import java.nio.charset.StandardCharsets;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicLong;
@@ -23,7 +22,8 @@ public class OrderFixture {
     return UUID.nameUUIDFromBytes(String.valueOf(count).getBytes(StandardCharsets.UTF_8));
   }
 
-  public static Order createOrder(Member member, Shop shop, OrderStatus status, OrderType type, List<OrderMenu> orderMenuList) {
+  public static Order createOrder(Member member, Shop shop, OrderStatus status, OrderType type,
+      List<OrderMenu> orderMenuList) {
     int totalPrice = 0;
     for (OrderMenu orderMenu : orderMenuList) {
       totalPrice += orderMenu.getPrice();
@@ -41,6 +41,30 @@ public class OrderFixture {
         .build();
 
     ReflectionTestUtils.setField(order, "id", nextUUID());
+    ReflectionTestUtils.setField(order, "createdAt", LocalDateTime.now());
+    return order;
+  }
+
+  public static Order createExpiredOrder(Member member, Shop shop, OrderStatus status,
+      OrderType type, List<OrderMenu> orderMenuList) {
+    int totalPrice = 0;
+    for (OrderMenu orderMenu : orderMenuList) {
+      totalPrice += orderMenu.getPrice();
+    }
+
+    Order order = Order.builder()
+        .shop(shop)
+        .member(member)
+        .orderMenuList(orderMenuList)
+        .orderStatus(status)
+        .orderType(type)
+        .address("서울 어딘가")
+        .instruction("주문 요청 사항입니다.")
+        .totalPrice(totalPrice)
+        .build();
+
+    ReflectionTestUtils.setField(order, "id", nextUUID());
+    ReflectionTestUtils.setField(order, "createdAt", LocalDateTime.now().minusDays(1));
     return order;
   }
 }


### PR DESCRIPTION
## 요약
고객 주문 취소, 삭제 API 구현

## 작업 내용
- 고객 주문 취소 API 구현
  - 주문 요청 후 5분 이후의 요청에 대해서는 예외 처리
  - 이미 취소된 주문은 예외 처리
- 고객 주문 삭제 API 구현
- service 테스트 코드 작성
- http 테스트 완료

## 참고 사항


## 관련 이슈
#26 