### PR TITLE
RefreshToken / MASTER의 sign-up 기능 추가

### DIFF
--- a/src/main/java/com/fourseason/delivery/domain/member/entity/Member.java
+++ b/src/main/java/com/fourseason/delivery/domain/member/entity/Member.java
@@ -49,7 +49,7 @@ public class Member extends BaseTimeEntity {
                 .email(request.email())
                 .password(password)
                 .phoneNumber(request.phoneNumber())
-                .role(Role.CUSTOMER)
+                .role(Role.of(request.role()))
                 .build();
     }
 

--- a/src/main/java/com/fourseason/delivery/global/auth/JwtUtil.java
+++ b/src/main/java/com/fourseason/delivery/global/auth/JwtUtil.java
@@ -47,9 +47,9 @@ public class JwtUtil {
         return generateToken(Duration.ofMinutes(accessExpiration), username, claims);
     }
 
-    public String createRefreshToken(String username) {
+    public String createRefreshToken(Long id) {
 
-        return generateToken(Duration.ofDays(refreshExpiration), username, null);
+        return generateToken(Duration.ofDays(refreshExpiration), null, Map.of("id", id));
     }
 
     // 토큰 생성

--- a/src/main/java/com/fourseason/delivery/global/auth/controller/AuthController.java
+++ b/src/main/java/com/fourseason/delivery/global/auth/controller/AuthController.java
@@ -2,11 +2,10 @@ package com.fourseason.delivery.global.auth.controller;
 
 import com.fourseason.delivery.domain.member.entity.Role;
 import com.fourseason.delivery.global.auth.CustomPrincipal;
+import com.fourseason.delivery.global.auth.dto.TokenDto;
 import com.fourseason.delivery.global.auth.dto.request.SignInRequestDto;
 import com.fourseason.delivery.global.auth.dto.request.SignUpRequestDto;
-import com.fourseason.delivery.global.auth.dto.TokenDto;
 import com.fourseason.delivery.global.auth.service.AuthService;
-import com.fourseason.delivery.global.exception.CustomException;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -18,9 +17,6 @@ import org.springframework.web.bind.annotation.*;
 import org.springframework.web.util.UriComponentsBuilder;
 
 import java.net.URI;
-import java.util.Map;
-
-import static com.fourseason.delivery.global.auth.exception.AuthErrorCode.ACCESS_TOKEN_NOT_FOUND;
 
 @Slf4j
 @RestController

--- a/src/main/java/com/fourseason/delivery/global/auth/controller/AuthController.java
+++ b/src/main/java/com/fourseason/delivery/global/auth/controller/AuthController.java
@@ -1,5 +1,6 @@
 package com.fourseason.delivery.global.auth.controller;
 
+import com.fourseason.delivery.domain.member.entity.Role;
 import com.fourseason.delivery.global.auth.CustomPrincipal;
 import com.fourseason.delivery.global.auth.dto.request.SignInRequestDto;
 import com.fourseason.delivery.global.auth.dto.request.SignUpRequestDto;
@@ -8,6 +9,7 @@ import com.fourseason.delivery.global.auth.service.AuthService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.annotation.Secured;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -28,12 +30,29 @@ public class AuthController {
     public ResponseEntity<Void> signUp(
             @RequestBody @Valid SignUpRequestDto request
     ) {
-        authService.signUp(request);
+        SignUpRequestDto newMember = new SignUpRequestDto(
+                request.username(),
+                request.email(),
+                request.password(),
+                request.phoneNumber(),
+                Role.CUSTOMER.toString()
+        );
+        authService.signUp(newMember);
         URI location = UriComponentsBuilder.newInstance()
                 .path("/api/sign-in")
                 .build()
                 .toUri();
         return ResponseEntity.created(location).build();
+    }
+
+    @Secured("ROLE_MASTER")
+    @PostMapping("/admin/sign-up")
+    @ResponseStatus(HttpStatus.CREATED)
+    public String adminSignUp(
+            @RequestBody @Valid SignUpRequestDto request
+    ) {
+        authService.signUp(request);
+        return request.role() + " member 생셩.";
     }
 
     @PostMapping("/sign-in")
@@ -51,12 +70,12 @@ public class AuthController {
     @Secured("ROLE_MASTER")
     @GetMapping("/admin")
     public String admin(@AuthenticationPrincipal CustomPrincipal customPrincipal) {
-        return "admin name: " + customPrincipal.getName();
+        return "admin name: " + customPrincipal.getName() + " id: " + customPrincipal.getId();
     }
 
     @GetMapping("/member")
     public String member(@AuthenticationPrincipal CustomPrincipal customPrincipal) {
-        return "member name: " + customPrincipal.getName();
+        return "member name: " + customPrincipal.getName() + " id: " + customPrincipal.getId();
     }
 }
 

--- a/src/main/java/com/fourseason/delivery/global/auth/dto/request/SignUpRequestDto.java
+++ b/src/main/java/com/fourseason/delivery/global/auth/dto/request/SignUpRequestDto.java
@@ -1,6 +1,8 @@
 package com.fourseason.delivery.global.auth.dto.request;
 
-import jakarta.validation.constraints.*;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
 
 public record SignUpRequestDto (
         @NotBlank(message = "username 은 필수 항목 입니다.")
@@ -16,6 +18,10 @@ public record SignUpRequestDto (
         String password,
 
         @Pattern(regexp = "^\\d{3}-\\d{3,4}-\\d{4}$", message = "전화번호 형식에 맞게 입력해 주세요.")
-        String phoneNumber
+        String phoneNumber,
+
+        // 직접 받을 수 있는 항목을 넣었는데 enum 값 변경에 유연하지 않다...
+        @Pattern(regexp = "CUSTOMER|MANAGER|OWNER|MASTER", message = "권한 이름을 확인해 주세요.")
+        String role
 ) {
 }

--- a/src/main/java/com/fourseason/delivery/global/auth/exception/AuthErrorCode.java
+++ b/src/main/java/com/fourseason/delivery/global/auth/exception/AuthErrorCode.java
@@ -9,12 +9,11 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum AuthErrorCode implements ErrorCode {
 
-    ACCESS_TOKEN_NOT_FOUND(HttpStatus.UNAUTHORIZED, "유효한 토큰을 찾을 수 없습니다."),
-
-    // TODO: message 내용 다르게 고민..
-    ACCESS_TOKEN_NOT_AVAILABLE(HttpStatus.UNAUTHORIZED, "토큰 검증에 문제....")
+    ACCESS_TOKEN_NOT_FOUND(HttpStatus.UNAUTHORIZED, "토큰을 찾을 수 없습니다."),
+    ACCESS_TOKEN_NOT_AVAILABLE(HttpStatus.BAD_REQUEST, "유효하지 않은 토큰입니다. ACCESS"),
+    ACCESS_TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "토큰이 만료되었습니다."),
+    REFRESH_TOKEN_NOT_AVAILABLE(HttpStatus.BAD_REQUEST, "유효하지 않은 토큰입니다. REFRESH")
     ;
-
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/fourseason/delivery/global/auth/filter/JwtCheckFilter.java
+++ b/src/main/java/com/fourseason/delivery/global/auth/filter/JwtCheckFilter.java
@@ -4,6 +4,8 @@ import com.fourseason.delivery.global.auth.CustomPrincipal;
 import com.fourseason.delivery.global.auth.JwtUtil;
 import com.fourseason.delivery.global.exception.CustomException;
 import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtException;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -19,8 +21,7 @@ import org.springframework.web.filter.OncePerRequestFilter;
 import java.io.IOException;
 import java.util.Collections;
 
-import static com.fourseason.delivery.global.auth.exception.AuthErrorCode.ACCESS_TOKEN_NOT_AVAILABLE;
-import static com.fourseason.delivery.global.auth.exception.AuthErrorCode.ACCESS_TOKEN_NOT_FOUND;
+import static com.fourseason.delivery.global.auth.exception.AuthErrorCode.*;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -63,7 +64,10 @@ public class JwtCheckFilter extends OncePerRequestFilter {
             SecurityContextHolder.getContext().setAuthentication(authentication);
             filterChain.doFilter(request, response);
 
-        } catch (Exception e) {
+        } catch (ExpiredJwtException e) {
+            log.error(e.getMessage());
+            throw new CustomException(ACCESS_TOKEN_EXPIRED);
+        } catch (JwtException e) {
             log.error(e.getMessage());
             throw new CustomException(ACCESS_TOKEN_NOT_AVAILABLE);
         }
@@ -76,7 +80,6 @@ public class JwtCheckFilter extends OncePerRequestFilter {
             return bearerToken.substring(7);
         } else {
             // Access Token 이 없거나 prefix 가 Bearer 가 아닌 경우
-            log.info("ACCESS_TOKEN_NOT_FOUND: {}", bearerToken);
             throw new CustomException(ACCESS_TOKEN_NOT_FOUND);
         }
     }

--- a/src/main/java/com/fourseason/delivery/global/auth/filter/JwtCheckFilter.java
+++ b/src/main/java/com/fourseason/delivery/global/auth/filter/JwtCheckFilter.java
@@ -30,7 +30,7 @@ public class JwtCheckFilter extends OncePerRequestFilter {
 
     @Override
     protected boolean shouldNotFilter(HttpServletRequest request) {
-        return request.getServletPath().startsWith("/api");
+        return request.getServletPath().startsWith("/api/sign");
     }
 
     @Override
@@ -46,7 +46,7 @@ public class JwtCheckFilter extends OncePerRequestFilter {
         try {
 
             Claims claims = jwtUtil.validateToken(accessToken);
-            log.info(claims.toString());
+//            log.info(claims.toString());
 
             CustomPrincipal principal = new CustomPrincipal(claims.get("id", Long.class),
                     claims.getSubject());
@@ -60,11 +60,11 @@ public class JwtCheckFilter extends OncePerRequestFilter {
                                     new SimpleGrantedAuthority("ROLE_" + claims.get("role").toString())
                             )
                     );
-
             SecurityContextHolder.getContext().setAuthentication(authentication);
             filterChain.doFilter(request, response);
 
         } catch (Exception e) {
+            log.error(e.getMessage());
             throw new CustomException(ACCESS_TOKEN_NOT_AVAILABLE);
         }
     }

--- a/src/main/java/com/fourseason/delivery/global/auth/service/AuthService.java
+++ b/src/main/java/com/fourseason/delivery/global/auth/service/AuthService.java
@@ -1,7 +1,6 @@
 package com.fourseason.delivery.global.auth.service;
 
 import com.fourseason.delivery.domain.member.entity.Member;
-import com.fourseason.delivery.domain.member.entity.Role;
 import com.fourseason.delivery.domain.member.repository.MemberRepository;
 import com.fourseason.delivery.global.auth.JwtUtil;
 import com.fourseason.delivery.global.auth.dto.TokenDto;

--- a/src/main/java/com/fourseason/delivery/global/auth/service/AuthService.java
+++ b/src/main/java/com/fourseason/delivery/global/auth/service/AuthService.java
@@ -12,11 +12,8 @@ import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.JwtException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.ResponseEntity;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
-
-import java.util.Map;
 
 import static com.fourseason.delivery.domain.member.exception.MemberErrorCode.*;
 import static com.fourseason.delivery.global.auth.exception.AuthErrorCode.ACCESS_TOKEN_NOT_AVAILABLE;

--- a/src/main/java/com/fourseason/delivery/global/auth/service/AuthService.java
+++ b/src/main/java/com/fourseason/delivery/global/auth/service/AuthService.java
@@ -7,12 +7,20 @@ import com.fourseason.delivery.global.auth.dto.TokenDto;
 import com.fourseason.delivery.global.auth.dto.request.SignInRequestDto;
 import com.fourseason.delivery.global.auth.dto.request.SignUpRequestDto;
 import com.fourseason.delivery.global.exception.CustomException;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
+import java.util.Map;
+
 import static com.fourseason.delivery.domain.member.exception.MemberErrorCode.*;
+import static com.fourseason.delivery.global.auth.exception.AuthErrorCode.ACCESS_TOKEN_NOT_AVAILABLE;
+import static com.fourseason.delivery.global.auth.exception.AuthErrorCode.REFRESH_TOKEN_NOT_AVAILABLE;
 
 @Service
 @Slf4j
@@ -44,8 +52,38 @@ public class AuthService {
 
         // 토큰 생성
         String accessToken = jwtUtil.createAccessToken(member.getUsername(), member.getRole(), member.getId());
-        String refreshToken = jwtUtil.createRefreshToken(member.getUsername());
+        String refreshToken = jwtUtil.createRefreshToken(member.getId());
         return new TokenDto(accessToken, refreshToken);
+    }
+
+    public String refresh(String accessToken, String refreshToken) {
+        //  Access Token 이 만료되었는지 확인(만료가 정상)
+        try {
+            //  Refresh Token 검증
+            jwtUtil.validateToken(accessToken);
+
+            //  ExpiredJwtException 이 아니면 아직 만료 기한이 남아 있는 것이므로 그대로 리턴
+            log.info("Access Token is not expired.....................");
+
+            return accessToken;
+        } catch (ExpiredJwtException expiredJwtException) {
+            try {
+                //  Refresh 가 필요한 상황
+                Claims claims = jwtUtil.validateToken(refreshToken);
+                Member member = memberRepository.findById(claims.get("id", Long.class))
+                        .orElseThrow(() -> new CustomException(MEMBER_NOT_FOUND));
+
+                // access token 생성, refresh token 은 따로 관리하지 않아 재 생성 시 기존 토큰을 삭제할 수 없으므로
+                // refresh token 재발급은 하지 않음. (추후 관리 가능한 방법으로..)
+                return jwtUtil.createAccessToken(member.getUsername(), member.getRole(), member.getId());
+            } catch (Exception e) {
+                log.error(e.getMessage());
+                throw new CustomException(REFRESH_TOKEN_NOT_AVAILABLE);
+            }
+        } catch (JwtException e) {
+            log.error(e.getMessage());
+            throw new CustomException(ACCESS_TOKEN_NOT_AVAILABLE);
+        }
     }
 
     private void validateDuplicateEmail(String email) {

--- a/src/main/java/com/fourseason/delivery/global/auth/service/AuthService.java
+++ b/src/main/java/com/fourseason/delivery/global/auth/service/AuthService.java
@@ -1,6 +1,7 @@
 package com.fourseason.delivery.global.auth.service;
 
 import com.fourseason.delivery.domain.member.entity.Member;
+import com.fourseason.delivery.domain.member.entity.Role;
 import com.fourseason.delivery.domain.member.repository.MemberRepository;
 import com.fourseason.delivery.global.auth.JwtUtil;
 import com.fourseason.delivery.global.auth.dto.TokenDto;

--- a/src/test/java/com/fourseason/delivery/global/auth/JwtUtilTest.java
+++ b/src/test/java/com/fourseason/delivery/global/auth/JwtUtilTest.java
@@ -54,13 +54,13 @@ class JwtUtilTest {
     @Test
     @DisplayName("refresh 토큰 값 검증")
     void testGetMemberInfoFromRefreshToken() {
-        String token = jwtUtil.createRefreshToken("testUser");
+        String token = jwtUtil.createRefreshToken(5L);
 
         Claims claims = jwtUtil.validateToken(token);
 
         log.info("refresh 클레임 확인: {}", claims.toString());
 
         assertNotNull(claims);
-        assertEquals("testUser", claims.getSubject());
+        assertEquals(5L, claims.get("id", Long.class));
     }
 }


### PR DESCRIPTION
## 요약
Refresh Token 을 이용한 AccessToken 재발급
MASTER role MEMBER의 sign-up 기능

## 작업 내용
AccessToken 의 기한이 만료되면 Refresh Token을 /api/sign-refresh 로 함께 보내 새로운 AccessToken을 발급 받을 수 있음
MASTER 는 Role 을 추가하여 MEMBER를 생성할 수 있음. /api/admin/sign-up

## 참고 사항
현재 JwtCheckFilter 에서 /api/sign 으로 시작되는 요청은 bypass 하도록 구성되어
AccessToken이 만료되어도 RefreshToken 을 활용한 토큰 재발급 시 bypass 될 수 있도록 api uri를 /api/sign-refresh로 함.

MASTER의 MEMBER 생성 기능은 filter에서 토큰 검사를 해야 하므로 /api/admin/sign-up 으로 함.

## 관련 이슈
#32 