### PR TITLE
member address 기능 수정

### DIFF
--- a/src/main/java/com/fourseason/delivery/domain/member/controller/AddressController.java
+++ b/src/main/java/com/fourseason/delivery/domain/member/controller/AddressController.java
@@ -42,7 +42,7 @@ public class AddressController {
      * 주소 수정
      */
     @PutMapping("/{address_id}")
-    public ResponseEntity<AddressUpdateResponseDto> updateAddress(@PathVariable UUID addressId,
+    public ResponseEntity<AddressUpdateResponseDto> updateAddress(@PathVariable("address_id") UUID addressId,
                                                                   @Valid @RequestBody AddressUpdateRequestDto addressUpdateRequestDto) {
         return ResponseEntity.ok(addressService.updateAddress(addressId, addressUpdateRequestDto));
     }
@@ -52,7 +52,7 @@ public class AddressController {
      * 주소 삭제
      */
     @DeleteMapping("/{address_id}")
-    public ResponseEntity<Void> deleteAddress(@PathVariable UUID addressId) {
+    public ResponseEntity<Void> deleteAddress(@PathVariable("address_id") UUID addressId) {
         addressService.deleteAddress(addressId);
         return ResponseEntity.ok().build();
     }

--- a/src/main/java/com/fourseason/delivery/domain/member/entity/Address.java
+++ b/src/main/java/com/fourseason/delivery/domain/member/entity/Address.java
@@ -28,7 +28,7 @@ public class Address extends BaseTimeEntity {
     @Column(nullable = false)
     private String detailAddress;
 
-    @OneToOne
+    @ManyToOne
     @JoinColumn(name = "member_id")
     private Member member;
 

--- a/src/main/java/com/fourseason/delivery/domain/member/entity/Address.java
+++ b/src/main/java/com/fourseason/delivery/domain/member/entity/Address.java
@@ -34,7 +34,7 @@ public class Address extends BaseTimeEntity {
 
     @Builder
     public Address(String address, String detailAddress, Member member) {
-        this.address = detailAddress;
+        this.address = address;
         this.detailAddress = detailAddress;
         this.member = member;
     }


### PR DESCRIPTION
## 요약
member address 기능 수정

## 작업 내용
- Address 엔티티 주소 매핑 수정
  - address 필드에 address 값을 저장하도록 수정 (원래는 detailAddress가 매핑됨)
 - Address 엔티티 관계 설정 수정
   - member 필드와 관계를 @OneToOne 에서 @ManyToOne으로 수정
  - AddressController에서 @PathVariable 변수명 명시적으로 지정 

## 참고 사항

## 관련 이슈
close #27 