### PR TITLE
경로 설정 방식 수정Feature/auth refresh

### DIFF
--- a/src/main/java/com/fourseason/delivery/global/auth/filter/JwtCheckFilter.java
+++ b/src/main/java/com/fourseason/delivery/global/auth/filter/JwtCheckFilter.java
@@ -20,6 +20,7 @@ import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
 import java.util.Collections;
+import java.util.List;
 
 import static com.fourseason.delivery.global.auth.exception.AuthErrorCode.*;
 
@@ -29,10 +30,17 @@ public class JwtCheckFilter extends OncePerRequestFilter {
 
     private final JwtUtil jwtUtil;
 
+    // 지정한 경로로 시작되는 요청은 모두 제외 됨. 패턴은 적용안 됨.
+    private static final List<String> EXCLUDED_PATHS = List.of(
+            "/api/sign",
+            "/api/api-docs",
+            "/webjars"
+    );
+
     @Override
     protected boolean shouldNotFilter(HttpServletRequest request) {
-        String path = request.getServletPath();
-        return path.startsWith("/api") || path.startsWith("/swagger-ui") || path.startsWith("/v3/api-docs") || path.startsWith("/webjars");
+        String path = request.getRequestURI();
+        return EXCLUDED_PATHS.stream().anyMatch(path::startsWith);
     }
 
     @Override


### PR DESCRIPTION
## 요약
bypass 경로 설정 수정

## 작업 내용
지정 경로 설정을 static 필드에서 하도록 변경

## 참고 사항
지정한 경로로 시작되는 요청은 모두 토큰 검사를 안 함.
statsWith로 비교하므로 패턴 매칭은 안 됨

## 관련 이슈
#12 