### PR TITLE
가게 관리 리팩토링 및 테스트 코드 작성

### DIFF
--- a/src/main/java/com/fourseason/delivery/domain/menu/controller/MenuController.java
+++ b/src/main/java/com/fourseason/delivery/domain/menu/controller/MenuController.java
@@ -6,6 +6,7 @@ import com.fourseason.delivery.domain.menu.dto.response.MenuResponseDto;
 import com.fourseason.delivery.domain.menu.service.MenuService;
 import com.fourseason.delivery.global.dto.PageRequestDto;
 import com.fourseason.delivery.global.dto.PageResponseDto;
+import com.fourseason.delivery.global.resolver.PageSize;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import lombok.RequiredArgsConstructor;
@@ -29,7 +30,7 @@ public class MenuController {
     @GetMapping
     public ResponseEntity<PageResponseDto<MenuResponseDto>> getMenuList(@RequestParam UUID shopId,
                                                                         @RequestParam(defaultValue = "1") int page,
-                                                                        @RequestParam(defaultValue = "10") int size,
+                                                                        @PageSize int size,
                                                                         @RequestParam(defaultValue = "latest") String orderBy) {
         PageRequestDto pageRequestDto = PageRequestDto.of(page-1, size, orderBy);
         return ResponseEntity.ok(menuService.getMenuList(shopId, pageRequestDto));
@@ -79,7 +80,7 @@ public class MenuController {
     public ResponseEntity<PageResponseDto<MenuResponseDto>> searchMenu(@RequestParam @NotBlank(message = "검색어를 입력해주세요.") String keyword,
                                                                        @RequestParam @NotBlank(message = "가게 id 값을 입력해주세요.") UUID shopId,
                                                                        @RequestParam(defaultValue = "1") int page,
-                                                                       @RequestParam(defaultValue = "10") int size,
+                                                                       @PageSize int size,
                                                                        @RequestParam(defaultValue = "latest") String orderBy) {
         PageRequestDto pageRequestDto = PageRequestDto.of(page-1, size, orderBy);
         return ResponseEntity.ok(menuService.searchMenu(shopId, pageRequestDto, keyword));

--- a/src/main/java/com/fourseason/delivery/domain/menu/entity/MenuImage.java
+++ b/src/main/java/com/fourseason/delivery/domain/menu/entity/MenuImage.java
@@ -40,7 +40,7 @@ public class MenuImage extends BaseTimeEntity {
     private Menu menu;
 
     @Builder
-    public MenuImage(String imageUrl, String originalFileName, long fileSize, String s3Folder, Menu menu) {
+    private MenuImage(String imageUrl, String originalFileName, long fileSize, String s3Folder, Menu menu) {
         this.imageUrl = imageUrl;
         this.originalFileName = originalFileName;
         this.fileSize = fileSize;

--- a/src/main/java/com/fourseason/delivery/domain/shop/controller/ShopController.java
+++ b/src/main/java/com/fourseason/delivery/domain/shop/controller/ShopController.java
@@ -7,6 +7,7 @@ import com.fourseason.delivery.domain.shop.service.ShopService;
 import com.fourseason.delivery.global.auth.CustomPrincipal;
 import com.fourseason.delivery.global.dto.PageRequestDto;
 import com.fourseason.delivery.global.dto.PageResponseDto;
+import com.fourseason.delivery.global.resolver.PageSize;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import lombok.RequiredArgsConstructor;
@@ -30,7 +31,7 @@ public class ShopController {
      */
     @GetMapping
     public ResponseEntity<PageResponseDto<ShopResponseDto>> getShopList(@RequestParam(defaultValue = "1") int page,
-                                                                        @RequestParam(defaultValue = "10") int size,
+                                                                        @PageSize int size,
                                                                         @RequestParam(defaultValue = "latest") String orderBy) {
         PageRequestDto pageRequestDto = PageRequestDto.of(page-1, size, orderBy);
         return ResponseEntity.ok(shopService.getShopList(pageRequestDto));
@@ -81,10 +82,9 @@ public class ShopController {
     @GetMapping("/search")
     public ResponseEntity<PageResponseDto<ShopResponseDto>> searchShop(@RequestParam @NotBlank(message = "검색어를 입력해주세요.") String keyword,
                                                                        @RequestParam(defaultValue = "1") int page,
-                                                                       @RequestParam(defaultValue = "10") int size,
+                                                                       @PageSize int size,
                                                                        @RequestParam(defaultValue = "latest") String orderBy) {
         PageRequestDto pageRequestDto = PageRequestDto.of(page-1, size, orderBy);
         return ResponseEntity.ok(shopService.searchShop(pageRequestDto, keyword));
     }
-
 }

--- a/src/main/java/com/fourseason/delivery/domain/shop/controller/ShopController.java
+++ b/src/main/java/com/fourseason/delivery/domain/shop/controller/ShopController.java
@@ -4,12 +4,14 @@ import com.fourseason.delivery.domain.shop.dto.request.CreateShopRequestDto;
 import com.fourseason.delivery.domain.shop.dto.request.UpdateShopRequestDto;
 import com.fourseason.delivery.domain.shop.dto.response.ShopResponseDto;
 import com.fourseason.delivery.domain.shop.service.ShopService;
+import com.fourseason.delivery.global.auth.CustomPrincipal;
 import com.fourseason.delivery.global.dto.PageRequestDto;
 import com.fourseason.delivery.global.dto.PageResponseDto;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -47,8 +49,9 @@ public class ShopController {
      */
     @PostMapping
     public ResponseEntity<Void> registerShop(@RequestPart @Valid CreateShopRequestDto createShopRequestDto,
-                                             @RequestPart List<MultipartFile> images) {
-        shopService.registerShop(createShopRequestDto, images);
+                                             @RequestPart List<MultipartFile> images,
+                                             @AuthenticationPrincipal CustomPrincipal principal) {
+        shopService.registerShop(createShopRequestDto, images, principal.getId());
         return ResponseEntity.ok().build();
     }
 
@@ -65,8 +68,9 @@ public class ShopController {
      * 가게 삭제 API
      */
     @DeleteMapping("/{id}")
-    public ResponseEntity<Void> deleteShop(@PathVariable UUID id) {
-        shopService.deleteShop(id);
+    public ResponseEntity<Void> deleteShop(@PathVariable UUID id,
+                                           @AuthenticationPrincipal CustomPrincipal principal) {
+        shopService.deleteShop(id, principal.getId());
         return ResponseEntity.ok().build();
 
     }

--- a/src/main/java/com/fourseason/delivery/domain/shop/dto/request/CreateShopRequestDto.java
+++ b/src/main/java/com/fourseason/delivery/domain/shop/dto/request/CreateShopRequestDto.java
@@ -1,11 +1,9 @@
 package com.fourseason.delivery.domain.shop.dto.request;
 
-import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
-import org.springframework.web.multipart.MultipartFile;
+import lombok.Builder;
 
-import java.util.List;
-
+@Builder
 public record CreateShopRequestDto(
         @NotBlank(message = "가게 이름은 필수 입력 값입니다.")
         String name,

--- a/src/main/java/com/fourseason/delivery/domain/shop/entity/Category.java
+++ b/src/main/java/com/fourseason/delivery/domain/shop/entity/Category.java
@@ -2,6 +2,7 @@ package com.fourseason.delivery.domain.shop.entity;
 
 import com.fourseason.delivery.global.entity.BaseTimeEntity;
 import jakarta.persistence.*;
+import lombok.Builder;
 import lombok.Getter;
 import org.hibernate.annotations.UuidGenerator;
 
@@ -19,11 +20,9 @@ public class Category extends BaseTimeEntity {
     @Column(nullable = false)
     private String name;
 
-    public Category(String name) {
+    @Builder
+    private Category(String name) {
         this.name = name;
     }
 
-    public Category() {
-
-    }
 }

--- a/src/main/java/com/fourseason/delivery/domain/shop/entity/Shop.java
+++ b/src/main/java/com/fourseason/delivery/domain/shop/entity/Shop.java
@@ -47,7 +47,7 @@ public class Shop extends BaseTimeEntity {
     private Category category;
 
     @Builder
-    public Shop(String name, String description, String tel, String address, String detailAddress, Member member, Category category) {
+    private Shop(String name, String description, String tel, String address, String detailAddress, Member member, Category category) {
         this.name = name;
         this.description = description;
         this.tel = tel;

--- a/src/main/java/com/fourseason/delivery/domain/shop/entity/ShopImage.java
+++ b/src/main/java/com/fourseason/delivery/domain/shop/entity/ShopImage.java
@@ -40,7 +40,7 @@ public class ShopImage extends BaseTimeEntity {
     private Shop shop;
 
     @Builder
-    public ShopImage(String imageUrl, String originalFileName, long fileSize, String s3Folder, Shop shop) {
+    private ShopImage(String imageUrl, String originalFileName, long fileSize, String s3Folder, Shop shop) {
         this.imageUrl = imageUrl;
         this.originalFileName = originalFileName;
         this.fileSize = fileSize;

--- a/src/main/java/com/fourseason/delivery/domain/shop/service/ShopService.java
+++ b/src/main/java/com/fourseason/delivery/domain/shop/service/ShopService.java
@@ -2,9 +2,11 @@ package com.fourseason.delivery.domain.shop.service;
 
 import com.fourseason.delivery.domain.image.enums.S3Folder;
 import com.fourseason.delivery.domain.image.service.FileService;
+import com.fourseason.delivery.domain.member.MemberErrorCode;
 import com.fourseason.delivery.domain.member.entity.Member;
 import com.fourseason.delivery.domain.member.entity.Role;
 import com.fourseason.delivery.domain.member.repository.MemberRepository;
+import com.fourseason.delivery.domain.menu.exception.MenuErrorCode;
 import com.fourseason.delivery.domain.shop.dto.request.CreateShopRequestDto;
 import com.fourseason.delivery.domain.shop.dto.request.UpdateShopRequestDto;
 import com.fourseason.delivery.domain.shop.dto.response.ShopResponseDto;
@@ -62,13 +64,12 @@ public class ShopService {
     }
 
     @Transactional
-    public void registerShop(CreateShopRequestDto createShopRequestDto, List<MultipartFile> images) {
-        // TODO: 현재 임시 유저를 넣었음. 이후 수정 필요.
-        Member member = memberRepository.findById(1L)
-            .orElseThrow(() -> new IllegalArgumentException("해당 회원을 찾을 수 없습니다."));
+    public void registerShop(CreateShopRequestDto createShopRequestDto, List<MultipartFile> images, final Long memberId) {
+        Member member = memberRepository.findById(memberId)
+            .orElseThrow(() -> new CustomException(MemberErrorCode.MEMBER_NOT_FOUND));
 
         Category category = categoryRepository.findByName(createShopRequestDto.category())
-                .orElseThrow(() -> new CustomException(ShopErrorCode.CATEGORY_NOT_FOUND));
+            .orElseThrow(() -> new CustomException(ShopErrorCode.CATEGORY_NOT_FOUND));
 
         Shop shop = Shop.addOf(createShopRequestDto, member, category);
         shopRepository.save(shop);
@@ -90,12 +91,12 @@ public class ShopService {
     }
 
     @Transactional
-    public void deleteShop(final UUID id) {
+    public void deleteShop(final UUID id, final Long memberId) {
         Shop shop = shopRepository.findById(id)
-                .orElseThrow(() -> new CustomException(ShopErrorCode.SHOP_NOT_FOUND));
+            .orElseThrow(() -> new CustomException(ShopErrorCode.SHOP_NOT_FOUND));
 
-        // TODO: 현재 임시 유저를 넣었음. 이후 수정 필요.
-        Member member = new Member("유저", "user@example.com", "1234", "010-0000-0000", Role.CUSTOMER);
+        Member member = memberRepository.findById(memberId)
+            .orElseThrow(() -> new CustomException(MemberErrorCode.MEMBER_NOT_FOUND));
 
         shop.deleteOf(member.getUsername());
     }

--- a/src/main/java/com/fourseason/delivery/global/config/WebConfig.java
+++ b/src/main/java/com/fourseason/delivery/global/config/WebConfig.java
@@ -1,0 +1,22 @@
+package com.fourseason.delivery.global.config;
+
+import com.fourseason.delivery.global.resolver.PageSizeArgumentResolver;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.List;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+    private final PageSizeArgumentResolver pageSizeArgumentResolver;
+
+    public WebConfig(PageSizeArgumentResolver pageSizeArgumentResolver) {
+        this.pageSizeArgumentResolver = pageSizeArgumentResolver;
+    }
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(pageSizeArgumentResolver);
+    }
+}

--- a/src/main/java/com/fourseason/delivery/global/dto/PageRequestDto.java
+++ b/src/main/java/com/fourseason/delivery/global/dto/PageRequestDto.java
@@ -15,7 +15,7 @@ public class PageRequestDto {
     @Builder
     public PageRequestDto(int page, int size, String order) {
         this.page = page;
-        this.size = validateSize(size);
+        this.size = size;
         this.order = order;
     }
 
@@ -36,12 +36,5 @@ public class PageRequestDto {
 
     public long getFirstIndex() {
         return (long) this.page * this.size;
-    }
-
-    private int validateSize(int size) {
-        if (size == 10 || size == 30 || size == 50) {
-            return size;
-        }
-        return 10;
     }
 }

--- a/src/main/java/com/fourseason/delivery/global/resolver/PageSize.java
+++ b/src/main/java/com/fourseason/delivery/global/resolver/PageSize.java
@@ -1,0 +1,11 @@
+package com.fourseason.delivery.global.resolver;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface PageSize {
+}

--- a/src/main/java/com/fourseason/delivery/global/resolver/PageSizeArgumentResolver.java
+++ b/src/main/java/com/fourseason/delivery/global/resolver/PageSizeArgumentResolver.java
@@ -1,0 +1,40 @@
+package com.fourseason.delivery.global.resolver;
+
+import com.fourseason.delivery.global.exception.CustomException;
+import org.springframework.core.MethodParameter;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+import java.util.List;
+
+@Component
+public class PageSizeArgumentResolver implements HandlerMethodArgumentResolver {
+
+    private static final List<Integer> ALLOWED_PAGE_SIZES = List.of(10, 20, 30);
+    private static final int DEFAULT_SIZE = 10;
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.hasParameterAnnotation(PageSize.class) &&
+                parameter.getParameterType().equals(int.class);
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter,
+                                  ModelAndViewContainer mavContainer,
+                                  NativeWebRequest webRequest,
+                                  WebDataBinderFactory binderFactory) {
+        String paramValue = webRequest.getParameter("size");
+
+        if (paramValue == null) {
+            return DEFAULT_SIZE;
+        }
+
+        int page = Integer.parseInt(paramValue);
+        return ALLOWED_PAGE_SIZES.contains(page) ? page : 10;
+    }
+}

--- a/src/test/java/com/fourseason/delivery/domain/shop/controller/ShopControllerTest.java
+++ b/src/test/java/com/fourseason/delivery/domain/shop/controller/ShopControllerTest.java
@@ -1,0 +1,218 @@
+package com.fourseason.delivery.domain.shop.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fourseason.delivery.domain.shop.dto.request.CreateShopRequestDto;
+import com.fourseason.delivery.domain.shop.dto.response.ShopResponseDto;
+import com.fourseason.delivery.domain.shop.exception.ShopErrorCode;
+import com.fourseason.delivery.domain.shop.service.ShopService;
+import com.fourseason.delivery.global.annotation.WithCustomMockUser;
+import com.fourseason.delivery.global.dto.PageResponseDto;
+import com.fourseason.delivery.global.exception.CustomException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(controllers = ShopController.class)
+@ExtendWith(MockitoExtension.class)
+@WithCustomMockUser
+class ShopControllerTest {
+
+    @MockitoBean
+    private ShopService shopService;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    private final UUID shopId = UUID.fromString("e3c7a4b4-5aaf-4c7d-bdff-c64dbf7ef6f9");
+
+    @Nested
+    @DisplayName("가게 목록 조회")
+    class 가게_목록_조회 {
+
+        @Test
+        @DisplayName("성공")
+        void 성공() throws Exception {
+            // given
+            ShopResponseDto responseDto = getShopListResDto();
+            PageResponseDto<ShopResponseDto> pageResponseDto = new PageResponseDto<>(List.of(responseDto), 1);
+
+            given(shopService.getShopList(any())).willReturn(pageResponseDto);
+
+            // when & then
+            ResultActions actions = mockMvc.perform(get("/api/shops")
+                .param("page", "1")
+                .param("size", "10"));
+
+            actions.andExpect(status().isOk())
+                .andExpect(jsonPath("$.result[0].name").value("00피자"))
+                .andExpect(jsonPath("$.totalElements").value(1));
+        }
+
+        private ShopResponseDto getShopListResDto() {
+            return ShopResponseDto.builder()
+                .id(shopId.toString())
+                .name("00피자")
+                .description("맛있는 피자")
+                .tel("010-1234-5678")
+                .address("서울시 강남구")
+                .detailAddress("2층")
+                .images(List.of("image1.jpg", "image2.jpg"))
+                .build();
+        }
+    }
+
+    @Nested
+    @DisplayName("가게 상세 조회")
+    class 가게_상세_조회 {
+
+        @Test
+        @DisplayName("성공")
+        void 성공() throws Exception {
+
+            // given
+            ShopResponseDto responseDto = getShopListResDto();
+
+            given(shopService.getShop(shopId)).willReturn(responseDto);
+
+            // when & then
+            ResultActions actions = mockMvc.perform(get("/api/shops/{shopId}", shopId));
+
+            actions.andExpect(status().isOk())  // 응답 상태 코드가 200 OK인지 확인
+                .andExpect(jsonPath("$.name").value("00피자"))
+                .andExpect(jsonPath("$.description").value("맛있는 피자"))
+                .andExpect(jsonPath("$.tel").value("010-1234-5678"))
+                .andExpect(jsonPath("$.address").value("서울시 강남구"));
+        }
+
+        @Test
+        @DisplayName("실패 - 존재하지 않는 가게 ID")
+        void 실패_존재하지_않는_가게_ID() throws Exception {
+            // given
+            given(shopService.getShop(shopId)).willThrow(new CustomException(ShopErrorCode.SHOP_NOT_FOUND));
+
+            // when & then
+            ResultActions actions = mockMvc.perform(get("/api/shops/{shopId}", shopId));
+
+            actions.andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.message").value(ShopErrorCode.SHOP_NOT_FOUND.getMessage()));
+        }
+
+        private ShopResponseDto getShopListResDto() {
+            return ShopResponseDto.builder()
+                .id(shopId.toString())
+                .name("00피자")
+                .description("맛있는 피자")
+                .tel("010-1234-5678")
+                .address("서울시 강남구")
+                .detailAddress("2층")
+                .images(List.of("image1.jpg", "image2.jpg"))
+                .build();
+        }
+    }
+
+    @Nested
+    @DisplayName("가게 등록")
+    class 가게_등록 {
+
+        @Test
+        @DisplayName("성공")
+        void 성공() throws Exception {
+            // given
+            CreateShopRequestDto requestDto = getCreateShopRequestDto();
+
+            MockMultipartFile requestDtoFile = new MockMultipartFile(
+                "createShopRequestDto",
+                null,
+                MediaType.APPLICATION_JSON_VALUE,
+                objectMapper.writeValueAsString(requestDto).getBytes()
+            );
+            MockMultipartFile imageFile = new MockMultipartFile(
+                "images",
+                "image.jpg",
+                "image/jpeg",
+                "dummy image content".getBytes()
+            );
+
+            // when & then
+            ResultActions actions = mockMvc.perform(multipart("/api/shops")
+                    .file(requestDtoFile)
+                    .file(imageFile)
+                    .with(csrf().asHeader())
+                    .accept(MediaType.APPLICATION_JSON)
+                    .contentType(MediaType.MULTIPART_FORM_DATA)
+                );
+
+            actions
+                .andExpect(status().isOk())
+                .andExpect(content().string(""));
+
+            then(shopService).should().registerShop(any(), any(), any());
+        }
+
+        private CreateShopRequestDto getCreateShopRequestDto() {
+            return CreateShopRequestDto.builder()
+                .name("00피자")
+                .description("맛있는 피자")
+                .tel("010-1234-5678")
+                .address("서울시 강남구")
+                .detailAddress("2층")
+                .category("피자")
+                .build();
+        }
+    }
+
+    @Nested
+    @DisplayName("가게 삭제")
+    class 가게_삭제 {
+
+        @Test
+        @DisplayName("성공")
+        void 성공() throws Exception {
+
+            // when & then
+            ResultActions actions = mockMvc.perform(delete("/api/shops/{shopId}", shopId)
+                .with(csrf().asHeader()));
+
+            actions
+                .andExpect(status().isOk())
+                .andExpect(content().string(""));
+        }
+
+        @Test
+        @DisplayName("실패 - 존재하지 않는 ID")
+        void 실패_존재하지_않는_ID() throws Exception {
+
+            // given
+            willThrow(new CustomException(ShopErrorCode.SHOP_NOT_FOUND)).given(shopService).deleteShop(shopId, 1L);
+
+            // when & then
+            ResultActions actions = mockMvc.perform(delete("/api/shops/{shopId}", shopId)
+                .with(csrf().asHeader()));
+
+            actions.andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.message").value(ShopErrorCode.SHOP_NOT_FOUND.getMessage()));
+        }
+    }
+}

--- a/src/test/java/com/fourseason/delivery/domain/shop/service/ShopServiceTest.java
+++ b/src/test/java/com/fourseason/delivery/domain/shop/service/ShopServiceTest.java
@@ -1,0 +1,302 @@
+package com.fourseason.delivery.domain.shop.service;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+
+import com.fourseason.delivery.domain.image.enums.S3Folder;
+import com.fourseason.delivery.domain.image.service.FileService;
+import com.fourseason.delivery.domain.member.MemberErrorCode;
+import com.fourseason.delivery.domain.member.entity.Member;
+import com.fourseason.delivery.domain.member.repository.MemberRepository;
+import com.fourseason.delivery.domain.shop.dto.request.CreateShopRequestDto;
+import com.fourseason.delivery.domain.shop.dto.response.ShopResponseDto;
+import com.fourseason.delivery.domain.shop.entity.Category;
+import com.fourseason.delivery.domain.shop.entity.Shop;
+import com.fourseason.delivery.domain.shop.entity.ShopImage;
+import com.fourseason.delivery.domain.shop.exception.ShopErrorCode;
+import com.fourseason.delivery.domain.shop.repository.CategoryRepository;
+import com.fourseason.delivery.domain.shop.repository.ShopImageRepository;
+import com.fourseason.delivery.domain.shop.repository.ShopRepositoryCustom;
+import com.fourseason.delivery.global.dto.PageResponseDto;
+import com.fourseason.delivery.global.exception.CustomException;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import com.fourseason.delivery.domain.shop.repository.ShopRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+@ExtendWith(MockitoExtension.class)
+class ShopServiceTest {
+
+    @Mock
+    private ShopRepository shopRepository;
+
+    @Mock
+    private ShopRepositoryCustom shopRepositoryCustom;
+
+    @Mock
+    private ShopImageRepository shopImageRepository;
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @Mock
+    private CategoryRepository categoryRepository;
+
+    @Mock
+    private FileService fileService;
+
+    @InjectMocks
+    private ShopService shopService;
+
+    private final UUID shopId = UUID.fromString("e3c7a4b4-5aaf-4c7d-bdff-c64dbf7ef6f9");
+
+    @Nested
+    @DisplayName("가게 목록 조회")
+    class 가게_목록_조회 {
+
+        @Test
+        @DisplayName("성공")
+        void 성공() {
+            // given
+            given(shopRepositoryCustom.findShopListWithPage(any())).willReturn(new PageResponseDto<>(Collections.singletonList(ShopResponseDto.builder().build()), 1));
+
+            // when
+            PageResponseDto<ShopResponseDto> result = shopService.getShopList(any());
+
+            // then
+            assertThat(result).isNotNull();
+            then(shopRepositoryCustom).should().findShopListWithPage(any());
+        }
+    }
+
+    @Nested
+    @DisplayName("가게 상세 조회")
+    class 가게_상세_조회 {
+
+        @Test
+        @DisplayName("성공")
+        void 성공() {
+            // given
+            Shop shop = Mockito.spy(Shop.class);
+            given(shop.getId()).willReturn(shopId);
+
+            given(shop.getName()).willReturn("00피자");
+            given(shop.getDescription()).willReturn("맛있는 피자");
+            given(shop.getTel()).willReturn("010-1234-5678");
+            given(shop.getAddress()).willReturn("서울시 강남구");
+            given(shop.getDetailAddress()).willReturn("2층");
+
+            ShopImage shopImage1 = Mockito.spy(ShopImage.class);
+            given(shopImage1.getImageUrl()).willReturn("image1.jpg");
+
+            ShopImage shopImage2 = Mockito.spy(ShopImage.class);
+            given(shopImage2.getImageUrl()).willReturn("image2.jpg");
+
+            given(shopRepository.findByIdAndDeletedAtIsNull(shopId)).willReturn(Optional.of(shop));
+            given(shopImageRepository.findByShopId(shopId)).willReturn(List.of(shopImage1, shopImage2));
+
+            // when
+            ShopResponseDto result = shopService.getShop(shopId);
+
+            // then
+            assertThat(result).isNotNull();
+            assertThat(result.images()).hasSize(2);
+            then(shopRepository).should().findByIdAndDeletedAtIsNull(shopId);
+            then(shopImageRepository).should().findByShopId(shopId);
+        }
+
+        @Test
+        @DisplayName("실패 - 존재하지 않는 가게")
+        void 실패_존재하지_않는_가게() {
+            // given
+            given(shopRepository.findByIdAndDeletedAtIsNull(shopId)).willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> shopService.getShop(shopId))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessageContaining(ShopErrorCode.SHOP_NOT_FOUND.getMessage());
+
+            then(shopRepository).should().findByIdAndDeletedAtIsNull(shopId);
+        }
+    }
+
+    @Nested
+    @DisplayName("가게 등록")
+    class 가게_등록 {
+
+        @Test
+        @DisplayName("성공 - 이미지 O")
+        void 성공_이미지_O() {
+            // given
+            CreateShopRequestDto requestDto = new CreateShopRequestDto("00피자", "맛있는 피자", "010-1234-5678", "서울시 강남구", "2층", "카테고리");
+            List<MultipartFile> images = List.of(
+                    new MockMultipartFile("file1", "image1.jpg", "image/jpeg", "test1".getBytes()),
+                    new MockMultipartFile("file2", "image2.jpg", "image/jpeg", "test2".getBytes())
+            );
+            Long memberId = 1L;
+
+            Member member = Member.builder().build();
+            ReflectionTestUtils.setField(member, "id", memberId);
+
+            Category category = Category.builder().name("카테고리").build();
+            Shop shop = Shop.addOf(requestDto, member, category);
+
+            given(memberRepository.findById(memberId)).willReturn(Optional.of(member));
+            given(categoryRepository.findByName("카테고리")).willReturn(Optional.of(category));
+            given(shopRepository.save(any())).willReturn(shop);
+
+            // when
+            shopService.registerShop(requestDto, images, memberId);
+
+            // then
+            then(memberRepository).should().findById(memberId);
+            then(categoryRepository).should().findByName("카테고리");
+            then(shopRepository).should().save(any());
+            then(fileService).should(times(2)).saveImageFile(eq(S3Folder.SHOP), any(), any());
+        }
+
+        @Test
+        @DisplayName("성공 - 이미지 X")
+        void 성공_이미지_X() {
+            // given
+            CreateShopRequestDto requestDto = new CreateShopRequestDto("00피자", "맛있는 피자", "010-1234-5678", "서울시 강남구", "2층", "카테고리");
+            List<MultipartFile> images = Collections.emptyList(); // 이미지 없음
+            Long memberId = 1L;
+
+            Member member = Member.builder().build();
+            ReflectionTestUtils.setField(member, "id", memberId);
+
+            Category category = Category.builder().name("카테고리").build();
+            Shop shop = Shop.addOf(requestDto, member, category);
+
+            given(memberRepository.findById(memberId)).willReturn(Optional.of(member));
+            given(categoryRepository.findByName("카테고리")).willReturn(Optional.of(category));
+            given(shopRepository.save(any())).willReturn(shop);
+
+            // when
+            shopService.registerShop(requestDto, images, memberId);
+
+            // then
+            then(memberRepository).should().findById(memberId);
+            then(categoryRepository).should().findByName("카테고리");
+            then(shopRepository).should().save(any());
+            then(fileService).should(never()).saveImageFile(eq(S3Folder.SHOP), any(), any());
+        }
+
+        @Test
+        @DisplayName("실패 - 존재하지 않는 회원")
+        void 실패_존재하지_않는_회원() {
+            // given
+            CreateShopRequestDto requestDto = new CreateShopRequestDto("00피자", "맛있는 피자", "010-1234-5678", "서울시 강남구", "2층", "카테고리");
+            Long memberId = 1L;
+
+            given(memberRepository.findById(memberId)).willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> shopService.registerShop(requestDto, Collections.emptyList(), memberId))
+                .isInstanceOf(CustomException.class)
+                .hasMessageContaining(MemberErrorCode.MEMBER_NOT_FOUND.getMessage());
+
+            then(memberRepository).should().findById(memberId);
+            then(categoryRepository).should(never()).findByName(any());
+            then(shopRepository).should(never()).save(any());
+            then(fileService).should(never()).saveImageFile(any(), any(), any());
+        }
+
+        @Test
+        @DisplayName("실패 - 존재하지 않는 카테고리")
+        void 실패_존재하지_않는_카테고리() {
+            // given
+            CreateShopRequestDto requestDto = new CreateShopRequestDto("00피자", "맛있는 피자", "010-1234-5678", "서울시 강남구", "2층", "카테고리");
+            Long memberId = 1L;
+
+            Member member = Member.builder().build();
+            ReflectionTestUtils.setField(member, "id", memberId);
+
+            given(memberRepository.findById(memberId)).willReturn(Optional.of(member));
+            given(categoryRepository.findByName("카테고리")).willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> shopService.registerShop(requestDto, Collections.emptyList(), memberId))
+                .isInstanceOf(CustomException.class)
+                .hasMessageContaining(ShopErrorCode.CATEGORY_NOT_FOUND.getMessage());
+
+            then(memberRepository).should().findById(memberId);
+            then(categoryRepository).should().findByName("카테고리");
+            then(shopRepository).should(never()).save(any());
+            then(fileService).should(never()).saveImageFile(any(), any(), any());
+        }
+    }
+
+    @Nested
+    @DisplayName("가게 삭제")
+    class 가게_삭제 {
+
+        private final Long memberId = 1L;
+
+        @Test
+        @DisplayName("성공")
+        void 성공() {
+            // given
+            Member member = Member.builder().build();
+            ReflectionTestUtils.setField(member, "id", memberId);
+
+            Shop shop = Mockito.mock(Shop.class);
+            given(shopRepository.findById(shopId)).willReturn(Optional.of(shop));
+            given(memberRepository.findById(memberId)).willReturn(Optional.of(member));
+
+            // when
+            shopService.deleteShop(shopId, memberId);
+
+            // then
+            then(shopRepository).should().findById(shopId);
+            then(memberRepository).should().findById(memberId);
+            then(shop).should().deleteOf(member.getUsername());
+        }
+
+        @Test
+        @DisplayName("가게가 존재하지 않으면 예외 발생")
+        void 가게_존재하지_않음() {
+            // given
+            given(shopRepository.findById(shopId)).willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> shopService.deleteShop(shopId, memberId))
+                .isInstanceOf(CustomException.class)
+                .hasMessage(ShopErrorCode.SHOP_NOT_FOUND.getMessage());
+        }
+
+        @Test
+        @DisplayName("회원이 존재하지 않으면 예외 발생")
+        void 회원_존재하지_않음() {
+            // given
+            Shop shop = Mockito.mock(Shop.class);
+            given(shopRepository.findById(shopId)).willReturn(Optional.of(shop));
+            given(memberRepository.findById(memberId)).willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> shopService.deleteShop(shopId, memberId))
+                .isInstanceOf(CustomException.class)
+                .hasMessage(MemberErrorCode.MEMBER_NOT_FOUND.getMessage());
+        }
+    }
+}

--- a/src/test/java/com/fourseason/delivery/global/annotation/WithCustomMockUser.java
+++ b/src/test/java/com/fourseason/delivery/global/annotation/WithCustomMockUser.java
@@ -1,0 +1,16 @@
+package com.fourseason.delivery.global.annotation;
+
+import org.springframework.security.test.context.support.WithSecurityContext;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+@Retention(RetentionPolicy.RUNTIME)
+@WithSecurityContext(factory = WithCustomMockUserSecurityContextFactory.class)
+public @interface WithCustomMockUser {
+
+    long id() default 1L;
+
+    String username() default "username";
+
+}

--- a/src/test/java/com/fourseason/delivery/global/annotation/WithCustomMockUserSecurityContextFactory.java
+++ b/src/test/java/com/fourseason/delivery/global/annotation/WithCustomMockUserSecurityContextFactory.java
@@ -1,0 +1,20 @@
+package com.fourseason.delivery.global.annotation;
+
+import com.fourseason.delivery.global.auth.CustomPrincipal;
+import org.springframework.security.authentication.TestingAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.test.context.support.WithSecurityContextFactory;
+
+public class WithCustomMockUserSecurityContextFactory implements WithSecurityContextFactory<WithCustomMockUser> {
+
+    @Override
+    public SecurityContext createSecurityContext(WithCustomMockUser member) {
+        SecurityContext context = SecurityContextHolder.createEmptyContext();
+        CustomPrincipal principal = new CustomPrincipal(member.id(), member.username());
+        Authentication authentication = new TestingAuthenticationToken(principal, "", "CUSTOMER");
+        context.setAuthentication(authentication);
+        return context;
+    }
+}


### PR DESCRIPTION
## 요약

가게 관리 리팩토링 및 테스트 코드 작성

## 작업 내용
- 접근 제어자 변경
    - 정적 팩토리 메서드 사용으로 인한 생성자의 접근 제어자를 private으로 변경
- 가게 관리 기능에 로그인 유저 정보 연동
    - 기존 가게 등록, 삭제의 임시 유저 삭제
    - @AuthenticationPrincipal을 사용하여 로그인 유저 정보 적용
- 가게 관리 컨트롤러 테스트 코드 작성
    - @WithCustomMockUser 생성 및 적용
    - 가게 관리 컨트롤러 목록 조회, 상세 조회, 등록, 삭제 테스트 코드 작성
- 페이지 크기 값 검증을 Argument Resolver로 처리
    - size 값이 10, 20, 30만 허용되도록 Argument Resolver에서 검증
    - 유효하지 않은 값이 들어오면 기본값(10)으로 설정
    - PageRequestDto에서 검증 로직 제거하여 책임 분리
- 가게 관리 서비스 목록 조회, 상세 조회, 등록, 삭제 테스트 코드 작성

## 참고 사항


## 관련 이슈
