### PR TITLE
JWT 토큰 검증 필터에서 Swagger 경로 예외 처리 추가

### DIFF
--- a/src/main/java/com/fourseason/delivery/global/auth/filter/JwtCheckFilter.java
+++ b/src/main/java/com/fourseason/delivery/global/auth/filter/JwtCheckFilter.java
@@ -34,7 +34,11 @@ public class JwtCheckFilter extends OncePerRequestFilter {
     private static final List<String> EXCLUDED_PATHS = List.of(
             "/api/sign",
             "/api/api-docs",
-            "/webjars"
+            "/api/swagger-ui",
+            "/api/v2/api-docs",
+            "/api/swagger-resources",
+            "/v3/api-docs",
+            "/api/webjars"
     );
 
     @Override


### PR DESCRIPTION
## 요약

JWT 토큰 검증 필터에서 Swagger 경로 예외 처리 추가

## 작업 내용

- swagger 화이트라벨 페이지 문제 수정
- jwt 필터에서 swagger 경로 제외하여 해결

## 참고 사항


## 관련 이슈
